### PR TITLE
Fix ZeroDivisionError when STEPS_PER_INCREMENT < one PPO update (#18)

### DIFF
--- a/xlron/diff_sim/run_direct_optimization.py
+++ b/xlron/diff_sim/run_direct_optimization.py
@@ -82,7 +82,9 @@ def main(argv):
         model = orbax_checkpointer.restore(pathlib.Path(config.MODEL_PATH))
         config.model = model
 
-    NUM_UPDATES = config.TOTAL_TIMESTEPS // config.ROLLOUT_LENGTH // config.NUM_ENVS
+    # Guard against NUM_UPDATES rounding down to 0 (which causes a divide-by-zero in
+    # the lax.scan length and downstream reshapes; see GitHub issue #18).
+    NUM_UPDATES = max(1, config.TOTAL_TIMESTEPS // config.ROLLOUT_LENGTH // config.NUM_ENVS)
     MINIBATCH_SIZE = config.ROLLOUT_LENGTH * config.NUM_ENVS // config.NUM_MINIBATCHES
     config.NUM_UPDATES = NUM_UPDATES
     config.MINIBATCH_SIZE = MINIBATCH_SIZE

--- a/xlron/environments/make_env.py
+++ b/xlron/environments/make_env.py
@@ -174,12 +174,29 @@ def process_config(config: Optional[Union[dict, FlagValues]], **kwargs: Any) -> 
             scale_factor = int(config.get("scale_factor", 1))
             config.max_requests = int(config.STEPS_PER_INCREMENT) // num_envs // scale_factor
 
-        n_increments = config.TOTAL_TIMESTEPS // config.STEPS_PER_INCREMENT
+        if not is_eval:
+            # For RL training, an increment must contain at least one full PPO update
+            # (ROLLOUT_LENGTH * NUM_ENVS steps). Otherwise NUM_UPDATES rounds down to 0,
+            # which collapses STEPS_PER_INCREMENT and TOTAL_TIMESTEPS to 0 and triggers a
+            # "ZeroDivisionError: integer modulo by zero" in downstream metric reshapes
+            # (see GitHub issue #18). Bump STEPS_PER_INCREMENT up to one update and warn.
+            steps_per_update = config.ROLLOUT_LENGTH * config.NUM_ENVS
+            if config.STEPS_PER_INCREMENT < steps_per_update:
+                print(
+                    f"WARNING: STEPS_PER_INCREMENT ({config.STEPS_PER_INCREMENT}) is smaller "
+                    f"than one PPO update (ROLLOUT_LENGTH * NUM_ENVS = {steps_per_update}). "
+                    f"Increasing STEPS_PER_INCREMENT to {steps_per_update}."
+                )
+                config.STEPS_PER_INCREMENT = steps_per_update
+
+        n_increments = max(1, config.TOTAL_TIMESTEPS // config.STEPS_PER_INCREMENT)
         config.NUM_INCREMENTS = n_increments
         config.TOTAL_TIMESTEPS = n_increments * config.STEPS_PER_INCREMENT
         # Set derived config values for RL training (not used by eval, but kept consistent)
         config.MINIBATCH_SIZE = config.ROLLOUT_LENGTH * config.NUM_ENVS // config.NUM_MINIBATCHES
-        config.NUM_UPDATES = config.STEPS_PER_INCREMENT // config.ROLLOUT_LENGTH // config.NUM_ENVS
+        config.NUM_UPDATES = max(
+            1, config.STEPS_PER_INCREMENT // config.ROLLOUT_LENGTH // config.NUM_ENVS
+        )
         if not is_eval:
             # Only snap STEPS_PER_INCREMENT to ROLLOUT_LENGTH multiples for RL training.
             # For eval, STEPS_PER_INCREMENT controls episode count and must not be overwritten.

--- a/xlron/gui/presets.py
+++ b/xlron/gui/presets.py
@@ -27,6 +27,9 @@ PRESETS = {
         "TOTAL_TIMESTEPS": 100_000_000,
         "NUM_ENVS": 2000,
         "ROLLOUT_LENGTH": 150,
+        # = ROLLOUT_LENGTH * NUM_ENVS (one PPO update). The GUI default (100,000) is
+        # smaller than this, which would round NUM_UPDATES down to 0 (issue #18).
+        "STEPS_PER_INCREMENT": 300_000,
         "LR": 5e-4,
         "modulations_csv_filepath": "./xlron/data/modulations/modulations_deeprmsa.csv",
         "NUM_LAYERS": 5,
@@ -45,6 +48,9 @@ PRESETS = {
         "TOTAL_TIMESTEPS": 100_000_000,
         "NUM_ENVS": 2000,
         "ROLLOUT_LENGTH": 150,
+        # = ROLLOUT_LENGTH * NUM_ENVS (one PPO update). The GUI default (100,000) is
+        # smaller than this, which would round NUM_UPDATES down to 0 (issue #18).
+        "STEPS_PER_INCREMENT": 300_000,
         "LR": 5e-4,
     },
     "RL Training: NSFNET RSA": {
@@ -59,6 +65,9 @@ PRESETS = {
         "TOTAL_TIMESTEPS": 100_000_000,
         "NUM_ENVS": 2000,
         "ROLLOUT_LENGTH": 150,
+        # = ROLLOUT_LENGTH * NUM_ENVS (one PPO update). The GUI default (100,000) is
+        # smaller than this, which would round NUM_UPDATES down to 0 (issue #18).
+        "STEPS_PER_INCREMENT": 300_000,
         "LR": 5e-4,
     },
     "RSA GN Model Eval: NSFNET KSP-FF": {


### PR DESCRIPTION
Fixes #18.

## Problem

When `STEPS_PER_INCREMENT` is smaller than one full PPO update
(`ROLLOUT_LENGTH * NUM_ENVS`), `config.NUM_UPDATES` rounds down to `0` in
`process_config()`. That collapses `STEPS_PER_INCREMENT` and `TOTAL_TIMESTEPS`
to `0`, and the subsequent metric reshape
`x.reshape((num_learners_or_1, config.NUM_UPDATES, -1))` in `train_utils.py`
(and the `lax.scan` length in `ppo.py`) divides by zero:

```
ZeroDivisionError: integer modulo by zero
```

This is exactly what the GUI's **RL-training presets** hit: they leave
`STEPS_PER_INCREMENT` at the default `100,000` while using `NUM_ENVS=2000`,
`ROLLOUT_LENGTH=150` — so one update is `300,000` steps and `NUM_UPDATES`
becomes `0`.

## Fix

Central fix in `make_env.process_config()`:

- For RL training, if `STEPS_PER_INCREMENT` is below one full update, bump it
  up to one update (with a warning) **before** deriving `n_increments`. This
  keeps `TOTAL_TIMESTEPS` close to what was requested rather than inflating it.
- Guard `n_increments` and `NUM_UPDATES` with `max(1, ...)` as defence-in-depth.
- Apply the same `max(1, ...)` guard in `diff_sim/run_direct_optimization.py`.
- Set `STEPS_PER_INCREMENT=300_000` explicitly in the three RL-training GUI
  presets so they run out of the box.

Eval paths are unaffected: the clamp is gated on RL training, and eval already
short-circuits the loss reshape.

## Verification

- `process_config` unit checks across the original failing case, the fixed
  preset value, a degenerate `TOTAL_TIMESTEPS < one update` case, and the eval
  path — all yield `NUM_UPDATES >= 1` and reshape without error.
- End-to-end RL training that previously crashed
  (`--ROLLOUT_LENGTH=128 --NUM_ENVS=4 --STEPS_PER_INCREMENT=128`) now runs to
  completion, printing the warning and bumping `STEPS_PER_INCREMENT` to `512`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)