### PR TITLE
Fix GUI preset round-trip crash and MODEL_PATH override (#20)

### DIFF
--- a/xlron/gui/app.py
+++ b/xlron/gui/app.py
@@ -400,6 +400,14 @@ with col_widgets:
         log_flags = logging_section()
         all_flags.update(log_flags)
 
+# MODEL_PATH is a single CLI flag bound to two widgets: the load path in the
+# execution-mode section (Model Evaluation / Retrain) and the save path in the
+# logging section. The logging section renders last, so without this its
+# "Model Save Path" (often a stale preset value) would clobber a load path the
+# user just typed. Give the load-model path priority when that mode is active.
+if "MODEL_PATH" in mode_flags:
+    all_flags["MODEL_PATH"] = mode_flags["MODEL_PATH"]
+
 
 # ---------------------------------------------------------------------------
 # Build command and populate sidebar controls

--- a/xlron/gui/widgets.py
+++ b/xlron/gui/widgets.py
@@ -789,10 +789,18 @@ def traffic_section() -> dict:
 
     if warmup > 0:
         warmup_options = ["default", "heuristic", "random"]
+        # The CLI default (and the value emitted for the "default" option below)
+        # is None, so a saved preset stores warmup_action_type=None. Map None —
+        # and any unrecognised value — back to the "default" option.
+        warmup_preset = _get_preset_val("warmup_action_type")
+        warmup_current = "default" if warmup_preset is None else str(warmup_preset)
+        warmup_index = (
+            warmup_options.index(warmup_current) if warmup_current in warmup_options else 0
+        )
         warmup_action = st.selectbox(
             "Warmup Action Type",
             warmup_options,
-            index=warmup_options.index(str(_get_preset_val("warmup_action_type"))),
+            index=warmup_index,
             help="Action selection during warmup. 'default' uses the run mode's normal method "
             "(RL policy or heuristic). 'heuristic' forces the --path_heuristic. "
             "'random' samples uniformly from valid actions.",


### PR DESCRIPTION
Fixes #20.

Two bugs in the Streamlit GUI (`xlron/gui/`), both surfacing when a saved preset is loaded.

## 1. `ValueError: 'None' is not in list` when loading a preset

`traffic_section()` built the "Warmup Action Type" selectbox with:

```python
index=warmup_options.index(str(_get_preset_val("warmup_action_type")))
```

The `--warmup_action_type` CLI default is `None`, and the GUI emits `None` for the "default" option. So **any** config saved with `ENV_WARMUP_STEPS > 0` bakes `warmup_action_type=None` into the preset (this is how the reporter's `DeepRMSA_improved_nsfnet_evaluation` preset ended up with it — it derives from `RL Training: DeepRMSA`, which sets `ENV_WARMUP_STEPS: 3000`). On reload, `str(None)` → `"None"`, which isn't in `["default", "heuristic", "random"]`, so the page crashes.

**Fix:** map `None` — and any unrecognised value — back to the `"default"` option when computing the selectbox index.

## 2. Model Path not updating in Model Evaluation mode

`MODEL_PATH` is a single CLI flag bound to **two** widgets: the load path in the execution-mode section (Model Evaluation / Retrain) and the save path in the logging section. `logging_section()` renders last, so when a preset has `SAVE_MODEL: True` its "Model Save Path" widget (seeded from the stale preset value) overwrote the load path the user had just typed — the edited path silently never reached the command.

**Fix:** after merging the logging flags, give the load-model `MODEL_PATH` priority when Model Evaluation / Retrain mode is active, so edits in that widget stick.

## Testing
- Both files pass `ruff check` and `ruff format --check`.
- Verified the warmup index logic returns `default` for `None`/unknown inputs and the correct index for valid ones, with no exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)