### PR TITLE
Fix GUI execution-mode tabs breaking after loading a preset (#22)

### DIFF
--- a/xlron/gui/app.py
+++ b/xlron/gui/app.py
@@ -31,6 +31,16 @@ _LOGO_PATH = (
 _DOCS_URL = "https://micdoh.github.io/XLRON/"
 _PRESETS_PATH = Path(__file__).resolve().parent / "presets.py"
 
+# Flags that execution_mode_section() emits to mark the selected execution mode.
+# That section is the single source of truth for them: each render it re-emits
+# exactly the discriminators matching the mode radio. They must therefore NOT be
+# seeded from a loaded preset — otherwise a stale preset value (e.g.
+# EVAL_MODEL=True) survives after the user switches the radio to a mode that
+# doesn't set it, leaving the wrong tabs hidden and a stale flag in the command.
+_MODE_DISCRIMINATOR_FLAGS = frozenset(
+    {"EVAL_HEURISTIC", "EVAL_MODEL", "ACTION_OPTIMIZATION", "differentiable"}
+)
+
 
 # ---------------------------------------------------------------------------
 # Preset saving helpers
@@ -257,8 +267,17 @@ all_flags: dict = {}
 if "_loaded_preset" not in st.session_state:
     st.session_state["_loaded_preset"] = {}
 
-# Seed with preset values so flags without widgets are still included in the command
-all_flags.update(st.session_state.get("_loaded_preset", {}))
+# Seed with preset values so flags without widgets are still included in the
+# command. Mode-discriminator flags are excluded: execution_mode_section() owns
+# them and re-emits the ones matching the current mode, so seeding them here
+# would let a stale preset value survive a mode switch (see issue #22).
+all_flags.update(
+    {
+        k: v
+        for k, v in st.session_state.get("_loaded_preset", {}).items()
+        if k not in _MODE_DISCRIMINATOR_FLAGS
+    }
+)
 
 col_widgets, col_output = st.columns([3, 2])
 


### PR DESCRIPTION
## Problem

Reported in #22. After loading a preset and then switching the **Execution Mode** radio (e.g. from "Model Evaluation" or "Heuristic Evaluation" back to "RL Training"), the top-level tabs ("Setup", "Model & Training", "Physical Layer") don't track the change — the **Model & Training** tab stays hidden behind *"Model & Training options are only available in RL Training mode."*, and the generated command keeps a stale `--EVAL_MODEL` / `--EVAL_HEURISTIC`.

## Root cause

`app.py` seeds `all_flags` with the **entire** loaded preset, including the mode-discriminator flags `EVAL_HEURISTIC` / `EVAL_MODEL`. Tab visibility (`is_rl_mode`) and the command builder read those from `all_flags`.

But `execution_mode_section()` only re-emits a discriminator for the *currently selected* radio mode — "RL Training" emits none. So once a preset puts `EVAL_MODEL=True` into `all_flags`, switching the radio to "RL Training" returns an empty dict that can't override it. The stale value persists, hiding the wrong tab and leaking into the command.

(The Capacity-Bounds and Differentiable-Simulation modes were unaffected because they key off session state — `_bounds_mode` / `_diff_sim_mode` — which the section resets on every render. Only the `all_flags`-seeded `EVAL_*` flags leaked.)

## Fix

Make `execution_mode_section()` the single source of truth for the mode-discriminator flags: exclude them from the preset seed so only that section sets them, always matching the selected radio mode. This is one localized change in `app.py` — no per-widget `key=` plumbing or session-state juggling — which keeps the existing design intact and fixes both the tab visibility and the stale-command-flag symptoms.

## Verification

Reproduced and verified with Streamlit's `AppTest`:

1. Load a preset with `EVAL_MODEL=True` → mode radio shows "Model Evaluation", Model & Training tab correctly blocked, command contains `--EVAL_MODEL`.
2. Switch the radio to "RL Training" → Model & Training tab is now visible and `--EVAL_MODEL` is gone from the command.

Confirmed the test fails on the pre-fix code (the bug scenario) and passes with the fix.

## Note on the browser console warnings in the issue

The accessibility warnings quoted in the issue (empty `autocomplete`, missing `id`/`name`/`label` association) and the `preventOverflow`/`hide` popper.js console message are emitted by Streamlit's own widget/tooltip rendering, not by application code, so they're out of scope for this fix.
