### PR TITLE
Avoid per-path JAX device sync in init_path_link_array (large speedup for high-k env setup)

### DIFF
--- a/xlron/environments/env_funcs.py
+++ b/xlron/environments/env_funcs.py
@@ -654,9 +654,10 @@ def init_path_link_array(
     else:
         k_path_collections = [_compute_paths_for_pair(item) for item in work_items]
 
-    # --- Precompute modulations lookup (reversed once) ---
+    # --- Precompute modulations lookup (reversed once, as numpy) ---
+    # np.asarray avoids a JAX device sync per path in _get_spectral_efficiency below.
     if modulations_array is not None:
-        modulations_reversed = modulations_array[::-1]
+        modulations_reversed = np.asarray(modulations_array[::-1])
 
     def _get_spectral_efficiency(distance: float) -> float:
         if modulations_array is None:


### PR DESCRIPTION
## Summary

`init_path_link_array` builds the per-path spectral-efficiency table via a small helper:

```python
def _get_spectral_efficiency(distance):
    for modulation in modulations_reversed:
        if distance <= modulation[0]:   # modulation[0] is a JAX scalar
            return float(modulation[1])
```

`modulations_reversed` was a **JAX** array, so each `distance <= modulation[0]` comparison forces a `bool(jax_array)` → device→host sync. Done once per path while iterating every (node-pair × k) shortest path, this means **one device sync per path**.

For large topologies at high `k` this dominates environment-creation time — e.g. `usa100_directed` at `k=70` is ~700k paths, which was spending **tens of minutes** pegging a single CPU core (confirmed by a py-spy stack landing repeatedly in `_get_spectral_efficiency` with `jax/_src/array.py:__bool__ → _value`).

## Fix

Convert the modulations lookup to NumPy once, so the per-path comparisons are plain NumPy scalar ops with no device sync:

```python
modulations_reversed = np.asarray(modulations_array[::-1])
```

This is the same pattern the sibling `init_path_se_array` already uses. The values are unchanged — only the dtype of the lookup table.

## Validation

- **Correctness:** existing env/path tests pass unchanged (`env_funcs_test.py` + `rsa/rsa_test.py`: 512 passed, 119 skipped), since these build environments through `init_path_link_array`.
- **Behaviour-preserving + speedup (micro-benchmark, 20k path lookups):** identical results; **~374× faster** on CPU-jax (1.76 s → 0.005 s). On GPU the per-sync cost is far higher, which is what made the `usa100 × k=70` setup take ~40 min.

## Scope

One-line change (plus a comment). No functional/behavioural change; purely removes a device-sync hotspot in environment construction. Independent of any other in-flight work.

