### PR TITLE
Skip DRA throughput regression test on the public release

### DIFF
--- a/xlron/environments/gn_model/gn_model_test.py
+++ b/xlron/environments/gn_model/gn_model_test.py
@@ -1,5 +1,6 @@
 import pathlib
 import tempfile
+import unittest
 
 import chex
 import distrax
@@ -12,6 +13,16 @@ from xlron.environments.env_funcs import *
 from xlron.environments.make_env import make
 from xlron.environments.rsa import *
 from xlron.environments.wrappers import *
+
+# The public release of XLRON ships a stub for the Distributed Raman Amplification (DRA) GN model
+# (implementation withheld pending publication). Detect the stub by its sentinel so DRA-dependent
+# regression tests skip on the public release but still run where the full DRA model is present.
+try:
+    from xlron.environments.gn_model import isrs_gn_model_dra as _dra_module
+
+    _DRA_AVAILABLE = not hasattr(_dra_module, "_REMOVED_MESSAGE")
+except Exception:
+    _DRA_AVAILABLE = False
 
 
 # Module-level caches for expensive make() calls.
@@ -1021,6 +1032,10 @@ _GERARD_2025_PRESET = {
 }
 
 
+@unittest.skipUnless(
+    _DRA_AVAILABLE,
+    "DRA GN model implementation withheld from the public release of XLRON",
+)
 class Gerard2025RegressionTest(absltest.TestCase):
     """Regression test: Gerard 2025 preset with KSP-FF should produce a
     stable Shannon-Hartley throughput.  If this value changes, it means


### PR DESCRIPTION
## Problem

`gn_model_test.py::Gerard2025RegressionTest::test_throughput_regression` fails CI with:

```
NotImplementedError: The Distributed Raman Amplification (DRA) GN model implementation
has been removed from the public release of XLRON pending publication ...
```

The test uses the Gerard 2025 preset with `use_raman_amp=True`, which invokes the DRA GN model at env-creation time. The public release ships a **stub** for that model, so the test can't run here.

## Fix

Detect the stub via its `_REMOVED_MESSAGE` sentinel and skip the test class with `unittest.skipUnless` when the full DRA implementation is absent:

```python
try:
    from xlron.environments.gn_model import isrs_gn_model_dra as _dra_module
    _DRA_AVAILABLE = not hasattr(_dra_module, "_REMOVED_MESSAGE")
except Exception:
    _DRA_AVAILABLE = False
...
@unittest.skipUnless(_DRA_AVAILABLE, "DRA GN model implementation withheld from the public release of XLRON")
class Gerard2025RegressionTest(absltest.TestCase):
```

- On the **public release** (stub): the test is **skipped** → CI green.
- Where the **full DRA model is present**: the test runs unchanged.

Only this one test depends on DRA; all other GN-model tests are unaffected.

## Verification

`pytest xlron/environments/gn_model/gn_model_test.py` → **32 passed, 6 skipped, 0 failed** (the Gerard test is among the skips; the rest are pre-existing pmap/multi-device chex variant skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
