### PR TITLE
Wire bf16 compute for AMP-style mixed-precision training (~2.15x faster transformer)

### DIFF
--- a/xlron/models/mlp.py
+++ b/xlron/models/mlp.py
@@ -225,8 +225,10 @@ class ActorCriticMLP(eqx.Module):
         # Actor forward pass
         actor_key, critic_key = jax.random.split(key) if key else (None, None)
         logits = self.actor(x, key=actor_key) / self.temperature
-        action_dist = distrax.Categorical(logits=logits)
-        value = self.critic(x, key=critic_key)
+        # Cast outputs back to PARAMS_DTYPE (float32) so bf16 stays inside the model and the
+        # downstream PPO math / f32 env-state stay float32 (see transformer model for rationale).
+        action_dist = distrax.Categorical(logits=logits.astype(dtype_config.PARAMS_DTYPE))
+        value = self.critic(x, key=critic_key).astype(dtype_config.PARAMS_DTYPE)
         return action_dist, jnp.squeeze(value, axis=-1)
 
     def sample_action(

--- a/xlron/models/transformer.py
+++ b/xlron/models/transformer.py
@@ -587,7 +587,10 @@ class ActorCriticTransformer(eqx.Module):
 
         if params.include_no_op:
             action_logits = jnp.hstack([action_logits, jnp.array([-1e4])])
-        action_dist = distrax.Categorical(logits=action_logits)
+        # Cast outputs back to PARAMS_DTYPE (float32): under bf16 compute the logits/value are
+        # bf16, but the downstream PPO math and the f32 env-state fields (valid_mass etc.) require
+        # float32 -- otherwise the lax.scan carry dtype mismatches. Keeps bf16 inside the model.
+        action_dist = distrax.Categorical(logits=action_logits.astype(dtype_config.PARAMS_DTYPE))
 
         # CRITIC POOLING
         if self.critic_pooling == "attention":
@@ -603,7 +606,7 @@ class ActorCriticTransformer(eqx.Module):
             # Default: mean pooling
             pooled = jnp.mean(value_tokens, axis=0)
 
-        value = self.critic_mlp(pooled).squeeze()
+        value = self.critic_mlp(pooled).squeeze().astype(dtype_config.PARAMS_DTYPE)
 
         return action_dist, value
 

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -20,7 +20,12 @@ from xlron.environments.dataclasses import (
 from xlron.environments.env_funcs import process_path_action
 from xlron.environments.gn_model.isrs_gn_model import to_dbm
 from xlron.environments.wrappers import jit_profiler
-from xlron.train.train_utils import LossDiagnostics, TrainState, select_action
+from xlron.train.train_utils import (
+    LossDiagnostics,
+    TrainState,
+    cast_model_for_compute,
+    select_action,
+)
 
 RunnerState = Tuple[TrainState, LogEnvState, Obsv, Array, Array]
 UpdateState = Tuple[TrainState, RSATransition | VONETransition, Array, Array, Array, Any, Array]
@@ -386,6 +391,9 @@ def _env_rollout_advantages(
     axes = (0, None) if config.USE_GNN or config.USE_TRANSFORMER else (0,)
     # With Equinox, the model is called directly
     model = eqx.combine(train_state.model_params, train_state.model_static)
+    model = cast_model_for_compute(
+        model
+    )  # mixed-precision compute (no-op unless COMPUTE_DTYPE set)
     _, last_val = (
         jax.vmap(model, in_axes=axes)(*last_obs) if (config.NUM_ENVS > 1) else model(*last_obs)
     )
@@ -447,7 +455,10 @@ def _loss_fn(
     Compute PPO loss (actor + value + entropy).
     """
     traj_batch, adv, targets, importance_weights = batch_info
-    # RERUN NETWORK - with Equinox, vmap the model directly
+    # RERUN NETWORK - with Equinox, vmap the model directly.
+    # Mixed-precision compute: cast the (float32 master) weights to COMPUTE_DTYPE for the forward.
+    # This is inside the differentiated region, so gradients flow back to the float32 master.
+    model = cast_model_for_compute(model)
     axes = (0, None) if config.USE_GNN or config.USE_TRANSFORMER else (0,)
     pi, value = jax.vmap(model, in_axes=axes)(*traj_batch.obs)
 

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -910,6 +910,24 @@ def experiment_data_setup(config: Box, rng: chex.PRNGKey) -> Tuple:
     return init_runner_state, env, env_params
 
 
+def cast_model_for_compute(model: eqx.Module) -> eqx.Module:
+    """Cast a model's float (inexact) leaves to COMPUTE_DTYPE for the forward pass.
+
+    Mixed-precision *training*: the master weights stay at PARAMS_DTYPE (float32) in the
+    TrainState and optimizer, and are cast to COMPUTE_DTYPE (e.g. bfloat16) only for the forward
+    pass. Because the cast sits inside the differentiated region (it is applied to the model that
+    `_loss_fn` is differentiated through), gradients flow back through it to the float32 master
+    copy, so the optimizer keeps updating float32 weights. No-op when COMPUTE_DTYPE ==
+    PARAMS_DTYPE (the default), which avoids an unnecessary copy.
+    """
+    if jnp.dtype(dtype_config.COMPUTE_DTYPE) == jnp.dtype(dtype_config.PARAMS_DTYPE):
+        return model
+    return jax.tree_util.tree_map(
+        lambda x: x.astype(dtype_config.COMPUTE_DTYPE) if eqx.is_inexact_array(x) else x,
+        model,
+    )
+
+
 def select_action(select_action_state, env, env_params, train_state, config):
     """Select an action from the policy.
     If using VONE, the action is a tuple of (source, path, destination).
@@ -930,6 +948,7 @@ def select_action(select_action_state, env, env_params, train_state, config):
     if config.USE_GNN or config.USE_TRANSFORMER:
         last_obs = (env_state.env_state, env_params)
     model = eqx.combine(train_state.model_params, train_state.model_static)
+    model = cast_model_for_compute(model)
     pi, value = model(*last_obs)
     # Action masking
     mask_result = env.action_mask(env_state.env_state, env_params)


### PR DESCRIPTION
## Summary

**Builds on #25 (merged).** Makes `--compute_dtype=bfloat16` perform *real* bf16 model compute for training (automatic-mixed-precision style), so the **neural network** forward/backward runs in bfloat16 while **float32 master weights + optimizer** are kept for stability. This is the compute-side complement to #25 (which shrinks the *stored env-state*); together they cover both halves of mixed precision.

The transformer is matmul-bound, so this is where the *training* speedup lives.

### Results — GPU (A100 80GB), transformer USA100 (`usa100_directed`, `link_resources=320`, `k=70`)

| | EXECUTION FPS | peak GPU memory | blocking (incr 1 → 2) |
|---|---|---|---|
| float32 | 922 | 41.80 GB (38.9 GiB) | 0.047 → 0.051 |
| `--compute_dtype=bfloat16` | **1,970** | **33.77 GB (31.4 GiB)** | 0.050 → 0.030 (improving) |

- **~2.14× faster training**, trains **stably** (blocking improves across increments, no NaN, EXIT=0).
- **~19% lower peak GPU memory** (41.80 → 33.77 GB, −8.0 GB) at this batch (`NUM_ENVS=12`, batch 768). AMP keeps float32 master weights + Adam state unchanged, and the env-state is already f16 (#25), so only the forward/backward *activations* drop to bf16 — at batch 768 those are ~40% of the footprint, and their share (so the saving) grows with batch size. The bigger practical win is **headroom**: f32 OOM'd at `NUM_ENVS=512` (tried to allocate 1.86 TiB of activations); bf16 roughly halves per-sample activation cost, letting you push to a larger batch before OOM.

(For contrast, on the *un-wired* branch `--compute_dtype=bfloat16` was a no-op for the transformer — bf16 obs just promoted back to f32 against the f32 weights, FPS neutral at 936.)

## How it works

Standard AMP: keep a float32 master copy of the weights (and float32 Adam state), cast to bf16 only for the forward/backward.

- **`cast_model_for_compute(model)`** (`train_utils.py`): casts the model's float leaves to `COMPUTE_DTYPE` for the forward. Applied **inside `_loss_fn`** (so gradients flow back *through the cast* to the float32 master weights — the optimizer keeps updating float32), and at the `select_action` + last-value forwards. No-op when `COMPUTE_DTYPE == PARAMS_DTYPE` (the default), so float32 runs are byte-for-byte unchanged.
- **Model output cast**: the transformer/MLP cast their logits + value back to `PARAMS_DTYPE` (float32) before returning, so bf16 stays *inside* the model and the downstream PPO math + float32 env-state fields (`valid_mass`, value, advantages) don't change dtype — otherwise the `lax.scan` carry dtype mismatches.
- Master weights and Adam moments stay float32; **saved models are float32**.

## Scope / testing

- Verified on CPU (bf16 emulated) and on GPU (above): transformer + MLP train without scan-carry mismatch, finite returns/loss, in both default and `--compute_dtype=bfloat16` modes.
- **TODO (follow-up):** the GNN model's output dists/value still need the same `PARAMS_DTYPE` output cast for bf16 compute (`path_action_dist`, the launch-power dist/Beta, critic value). Transformer + MLP are done; GNN bf16 falls back/may mismatch until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)