### PR TITLE
Make VONE functional again: fix env creation, masking, undo accounting, and RL per-head action selection

### DIFF
--- a/xlron/environments/gn_model/gn_model_test.py
+++ b/xlron/environments/gn_model/gn_model_test.py
@@ -1111,7 +1111,7 @@ class RMSAGNAggregateSlotsTest(chex.TestCase):
         env, params = make(settings, log_wrapper=False)
         key = jax.random.PRNGKey(3)  # short-path request that passes SNR checks
         obs, state = env.reset(key, params)
-        mask, full_mask, mod_format_mask = env.action_mask(state, params)  # ty: ignore[unresolved-attribute]
+        mask, full_mask, mod_format_mask = env.action_mask(state, params)
         self.assertEqual(mask.shape[0], params.k_paths * 5)  # ceil(10 / 2) = 5
         self.assertEqual(mod_format_mask.shape[0], params.k_paths * 10)  # full resolution
         self.assertTrue(bool(jnp.any(mask > 0)))
@@ -1303,9 +1303,7 @@ class ScaledLaunchPowerTest(chex.TestCase):
         env, params = make(settings, log_wrapper=False)
         key = jax.random.PRNGKey(3)
         obs, state = env.reset(key, params)
-        power = get_launch_power(  # ty: ignore[invalid-argument-type,unresolved-attribute]
-            state, jnp.array(0), jnp.array(0.0), jnp.array(0), params
-        )
+        power = get_launch_power(state, jnp.array(0), jnp.array(0.0), jnp.array(0), params)
 
         nodes_sd, _ = read_rsa_request(state.request_array)
         source, dest = nodes_sd

--- a/xlron/environments/make_env.py
+++ b/xlron/environments/make_env.py
@@ -503,9 +503,12 @@ def make(
     # expensive KSP computation here for env types that don't need it,
     # UNLESS it's a GN model type that reads path_link_array.shape before
     # the second call.
-    _needs_modulation_resort = (
-        env_type not in ("rsa", "rwa", "rwa_lightpath_reuse") and path_sort_criteria != "distance"
+    # Mirror the consider_modulation_format derivation below: vone with slot_size==1
+    # never makes the modulation-aware call, so it must take the first call here.
+    _uses_modulation = env_type not in ("rsa", "rwa", "rwa_lightpath_reuse") and not (
+        env_type == "vone" and slot_size == 1
     )
+    _needs_modulation_resort = _uses_modulation and path_sort_criteria != "distance"
     _needs_first_call = not _needs_modulation_resort or env_type in (
         "rmsa_gn_model",
         "rsa_gn_model",

--- a/xlron/environments/rwa_lightpath_reuse/rwa_lightpath_reuse_test.py
+++ b/xlron/environments/rwa_lightpath_reuse/rwa_lightpath_reuse_test.py
@@ -713,7 +713,7 @@ class AggregateSlotsMaskTest(chex.TestCase):
         env, params = make(settings, log_wrapper=False)
         key = jax.random.PRNGKey(0)
         obs, state = env.reset(key, params)
-        mask, full_mask = env.action_mask(state, params)  # ty: ignore[unresolved-attribute]
+        mask, full_mask = env.action_mask(state, params)
         # k * ceil(5 / 2) = 5 * 3 aggregated actions; full mask stays k * 5
         self.assertEqual(mask.shape[0], 15)
         self.assertEqual(full_mask.shape[0], 25)
@@ -789,7 +789,7 @@ class MixedPrecisionCarryTest(chex.TestCase):
             obs, state = env.reset(key, params)
             init_dtype = state.link_slot_array.dtype
             self.assertEqual(init_dtype, dtype_config.SMALL_FLOAT_DTYPE)
-            mask, full_mask = env.action_mask(state, params)  # ty: ignore[unresolved-attribute]
+            mask, full_mask = env.action_mask(state, params)
             # Store masks at SMALL_FLOAT exactly as select_action does
             state = state.replace(
                 link_slot_mask=mask.astype(dtype_config.SMALL_FLOAT_DTYPE),
@@ -826,7 +826,7 @@ class DynamicExpiryCapacityRestoreTest(chex.TestCase):
         env, params = make(settings, log_wrapper=False)
         key = jax.random.PRNGKey(0)
         obs, state = env.reset(key, params)
-        mask, full_mask = env.action_mask(state, params)  # ty: ignore[unresolved-attribute]
+        mask, full_mask = env.action_mask(state, params)
         self.assertTrue(bool(jnp.any(mask > 0)))
         state = state.replace(link_slot_mask=mask, full_link_slot_mask=full_mask)
         _, state, *_ = jax.jit(env.step, static_argnums=(3,))(key, state, jnp.argmax(mask), params)

--- a/xlron/environments/vone/vone.py
+++ b/xlron/environments/vone/vone.py
@@ -127,10 +127,13 @@ class VONEEnv(environment.Environment):
         ),
     )
     def reset(
-        self, key: chex.PRNGKey, params: Optional[EnvParams] = None
+        self,
+        key: chex.PRNGKey,
+        params: Optional[EnvParams] = None,
+        state: Optional[VONEEnvState] = None,
     ) -> Tuple[Array, EnvState]:
         """Performs resetting of environment."""
-        obs, state = self.reset_env(key, params)
+        obs, state = self.reset_env(key, params, state)
         return obs, state
 
     def step_env(
@@ -203,6 +206,12 @@ class VONEEnv(environment.Environment):
             graph=init_graph_tuple(state, params, self.laplacian_matrix, exclude_source_dest=True)
         )
         info = {}
+        # Stash metrics so they survive the auto-reset in step(); LogWrapper pops these
+        # instead of reading the (possibly reset) state.
+        info["_accepted_services"] = state.accepted_services
+        info["_accepted_bitrate"] = state.accepted_bitrate
+        info["_total_bitrate"] = state.total_bitrate
+        info["_utilisation"] = jnp.count_nonzero(state.link_slot_array) / state.link_slot_array.size
         return self.get_obs(state), state, reward, terminal, truncated, info
 
     @partial(
@@ -212,11 +221,26 @@ class VONEEnv(environment.Environment):
             2,
         ),
     )
-    def reset_env(self, key: chex.PRNGKey, params: VONEEnvParams) -> Tuple[Array, VONEEnvState]:
+    def reset_env(
+        self,
+        key: chex.PRNGKey,
+        params: VONEEnvParams,
+        state: Optional[VONEEnvState] = None,
+    ) -> Tuple[Array, VONEEnvState]:
         """Environment-specific reset."""
         state = self.initial_state
         state = generate_vone_request(key, state, params)
         return self.get_obs(state), state
+
+    def action_mask(self, state: VONEEnvState, params: VONEEnvParams) -> Tuple[Array, Array]:
+        """Return the current path-slot masks (API parity with RSA-family envs).
+
+        VONE masking is per-head (action_mask_nodes / action_mask_dest_node /
+        action_mask_slots); this returns the stored path masks so shared code that
+        calls env.action_mask uniformly (e.g. select_action) works. The values are
+        only meaningful after action_mask_slots has been applied.
+        """
+        return state.link_slot_mask, state.full_link_slot_mask
 
     def action_mask_nodes(self, state: VONEEnvState, params: VONEEnvParams) -> Array:
         """Returns action mask for state."""
@@ -236,12 +260,17 @@ class VONEEnv(environment.Environment):
 
     def action_mask_slots(self, state: EnvState, params: EnvParams, action: Array) -> EnvState:
         """Returns action mask for state."""
+        # Temporarily swap in the RSA-style (source, slots, dest) request so the shared
+        # mask_slots can read it; restore the original VONE request_array before returning
+        # since the caller stores the returned state back into the carried env state.
+        orig_request_array = state.request_array
         formatted_request = format_vone_slot_request(state, action)
         state = state.replace(request_array=formatted_request)
         link_slot_mask, full_link_slot_mask = mask_slots(state, params)
         # Store at SMALL_FLOAT to keep the carried field dtype stable under mixed precision
         # (matches init_link_slot_mask); mask values are {0, 1}, exact in float16.
         state = state.replace(
+            request_array=orig_request_array,
             link_slot_mask=link_slot_mask.astype(dtype_config.SMALL_FLOAT_DTYPE),
             full_link_slot_mask=full_link_slot_mask.astype(dtype_config.SMALL_FLOAT_DTYPE),
         )

--- a/xlron/environments/vone/vone_funcs.py
+++ b/xlron/environments/vone/vone_funcs.py
@@ -83,7 +83,9 @@ def check_topology(action_history, topology_pattern):
         topology_pattern,
     )
     check = jnp.concatenate((check_virtual, check_physical))
-    return jnp.any(check)
+    # Padding positions of shorter (zero-padded) topology patterns keep the -1 sentinel in
+    # check_virtual (they are never visited by loop_func_virtual), so only count failures (1s)
+    return jnp.any(check > 0)
 
 
 def implement_node_action(
@@ -365,7 +367,10 @@ def generate_vone_request(key: chex.PRNGKey, state: VONEEnvState, params: VONEEn
 def undo_link_action_vone(state: VONEEnvState) -> VONEEnvState:
     """Undo tentative link slot assignments for VONE.
     Tentative assignments are indicated by negative values in link_slot_array and
-    link_slot_departure_array. Reset these to zero.
+    link_slot_departure_array. Add back the departure delta that the tentative placement
+    subtracted (mirrors complete_step_rsa), so that slots occupied by previously finalised
+    services recover their original positive departure times instead of being zeroed
+    (which would free the still-active service on the next expiry sweep).
 
     Args:
         state: Environment state
@@ -373,11 +378,18 @@ def undo_link_action_vone(state: VONEEnvState) -> VONEEnvState:
     Returns:
         Updated environment state
     """
+    # current_time/holding_time still hold the failing request's values here
+    # (they are only advanced afterwards, in generate_vone_request)
+    departure_delta = state.current_time + state.holding_time
     mask = jnp.where(state.link_slot_departure_array < zero, one, zero)
     mask = jnp.where(state.link_slot_array < -one, one, mask)
     state = state.replace(
         link_slot_array=jnp.where(mask == one, state.link_slot_array + one, state.link_slot_array),
-        link_slot_departure_array=jnp.where(mask == one, zero, state.link_slot_departure_array),
+        link_slot_departure_array=jnp.where(
+            mask == one,
+            state.link_slot_departure_array + departure_delta,
+            state.link_slot_departure_array,
+        ),
     )
     return state
 
@@ -711,11 +723,14 @@ def mask_nodes(state: VONEEnvState, num_nodes: chex.Scalar) -> VONEEnvState:
         def update_slice(j, x):
             return jax.lax.dynamic_update_slice_in_dim(x, jnp.array([0.0]), j, axis=0)
 
+        # action_history is float (LARGE_FLOAT_DTYPE); cast to int for use as a slice index
         val = jax.lax.cond(
             i % 2 == 0,
-            lambda x: update_slice(x[0][i], x[1]),  # i is node request index
             lambda x: update_slice(
-                x[0][i + 1], x[1]
+                x[0][i].astype(dtype_config.INDEX_DTYPE), x[1]
+            ),  # i is node request index
+            lambda x: update_slice(
+                x[0][i + 1].astype(dtype_config.INDEX_DTYPE), x[1]
             ),  # i is slot request index (so add 1 to get next node)
             (state.action_history, val),
         )

--- a/xlron/environments/vone/vone_test.py
+++ b/xlron/environments/vone/vone_test.py
@@ -12,9 +12,9 @@ import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
-import pytest
 from absl.testing import absltest, parameterized
 
+from xlron import dtype_config
 from xlron.environments.env_funcs import decrease_last_element
 from xlron.environments.dataclasses import *
 from xlron.environments.vone.vone_funcs import *
@@ -22,8 +22,6 @@ from xlron.environments.make_env import make
 from xlron.environments.rsa import *
 from xlron.environments.vone import *
 from xlron.environments.wrappers import *
-
-pytest.skip("VONE tests are currently disabled in CI", allow_module_level=True)
 
 
 def keys_test_setup():
@@ -910,6 +908,29 @@ class CheckTopologyTest(chex.TestCase):
         actual = self.variant(check_topology)(action_history, topology_pattern)
         chex.assert_trees_all_close(actual, expected)
 
+    @chex.all_variants()
+    @parameterized.named_parameters(
+        # Mixed-length virtual topologies: shorter patterns are zero-padded to the longest.
+        # Padding positions keep the -1 sentinel in action_history; the check must not
+        # count those sentinels as failures.
+        ("case_padded_bus_valid", jnp.array([2.0, 5, 1, 7, 0, -1, -1]), 0, jnp.array(False)),
+        ("case_padded_bus_virtual_clash", jnp.array([0.0, 5, 1, 7, 0, -1, -1]), 0, jnp.array(True)),
+        (
+            "case_padded_bus_physical_clash",
+            jnp.array([2.0, 5, 1, 7, 2, -1, -1]),
+            0,
+            jnp.array(True),
+        ),
+        ("case_full_ring_valid", jnp.array([1.0, 1, 3, 1, 2, 1, 1]), 1, jnp.array(False)),
+        ("case_full_ring_fail", jnp.array([0.0, 1, 3, 1, 2, 1, 1]), 1, jnp.array(True)),
+    )
+    def test_check_topology_mixed_length_patterns(self, action_history, pattern_idx, expected):
+        patterns = init_virtual_topology_patterns(["3_bus", "3_ring"])
+        pattern = patterns[pattern_idx]
+        topology_pattern = jax.lax.dynamic_slice(pattern, (3,), (pattern.shape[0] - 3,))
+        actual = self.variant(check_topology)(action_history, topology_pattern)
+        chex.assert_trees_all_close(actual, expected)
+
 
 class CheckVoneActionTest(chex.TestCase):
     def setUp(self):
@@ -1334,6 +1355,53 @@ class MaskNodesTest(chex.TestCase):
         node_mask = jnp.concatenate([state.node_mask_s, state.node_mask_d], axis=0)
         chex.assert_trees_all_close(node_mask, expected)
 
+    @chex.all_variants()
+    def test_mask_nodes_env_native_action_history(self):
+        # Regression test: the env-created action_history is float (LARGE_FLOAT_DTYPE), and
+        # mask_nodes uses its entries as dynamic_update_slice indices, which must be cast to
+        # int (previously raised TypeError at trace time for any real environment state).
+        self.assertEqual(self.state.action_history.dtype, jnp.dtype(dtype_config.LARGE_FLOAT_DTYPE))
+        state = self.variant(mask_nodes, static_argnums=(1,))(self.state, self.params.num_nodes)
+        chex.assert_shape(state.node_mask_s, (self.params.num_nodes,))
+        chex.assert_shape(state.node_mask_d, (self.params.num_nodes,))
+        # Fresh request: all nodes have capacity, so both masks should be all ones
+        chex.assert_trees_all_close(state.node_mask_s, jnp.ones(self.params.num_nodes))
+        chex.assert_trees_all_close(state.node_mask_d, jnp.ones(self.params.num_nodes))
+
+
+class UndoLinkActionVoneTest(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = vone_4node_test_setup()
+
+    @chex.all_variants()
+    def test_undo_restores_preexisting_departures(self):
+        # Regression test: undoing a tentative placement that collided with a previously
+        # finalised service must restore the finalised service's departure time (it was
+        # previously zeroed, causing the active service to be freed on the next expiry sweep).
+        link_slot_array = jnp.zeros_like(self.state.link_slot_array)
+        departure_array = jnp.zeros_like(self.state.link_slot_departure_array)
+        # Tentative delta for the failing request: current_time + holding_time = 20
+        state = self.state.replace(current_time=jnp.array(15.0), holding_time=jnp.array(5.0))
+        # Slot (0, 0): tentative placement on free spectrum -> (-1, -20)
+        link_slot_array = link_slot_array.at[0, 0].set(-1)
+        departure_array = departure_array.at[0, 0].set(-20.0)
+        # Slot (0, 1): tentative placement colliding with a finalised service (dep=50)
+        # -> (-2, 50 - 20)
+        link_slot_array = link_slot_array.at[0, 1].set(-2)
+        departure_array = departure_array.at[0, 1].set(30.0)
+        # Slot (0, 2): unrelated finalised service, untouched by the tentative action
+        link_slot_array = link_slot_array.at[0, 2].set(-1)
+        departure_array = departure_array.at[0, 2].set(40.0)
+        state = state.replace(
+            link_slot_array=link_slot_array, link_slot_departure_array=departure_array
+        )
+        updated_state = self.variant(undo_link_action_vone)(state)
+        expected_link_slot = jnp.zeros_like(link_slot_array).at[0, 2].set(-1).at[0, 1].set(-1)
+        expected_departure = jnp.zeros_like(departure_array).at[0, 1].set(50.0).at[0, 2].set(40.0)
+        chex.assert_trees_all_close(updated_state.link_slot_array, expected_link_slot)
+        chex.assert_trees_all_close(updated_state.link_slot_departure_array, expected_departure)
+
 
 class VoneActionMaskTest(chex.TestCase):
     def setUp(self):
@@ -1426,8 +1494,171 @@ class VoneActionMaskTest(chex.TestCase):
         state = self.variant(self.env.action_mask_slots, static_argnums=(1,))(
             state, self.params, action
         )
+        # Regression test: action_mask_slots must not leak the throwaway formatted
+        # (source, slots, dest) request into the returned (carried) state
+        chex.assert_trees_all_close(state.request_array, request_array)
         mask = jnp.concatenate([state.node_mask_s, state.link_slot_mask, state.node_mask_d], axis=0)
         chex.assert_trees_all_close(mask, expected)
+
+
+class VoneMakeTest(chex.TestCase):
+    def test_make_vone_default_path_sort(self):
+        # Regression test: make() previously crashed for env_type='vone' with slot_size=1 and
+        # the default path_sort_criteria ('spectral_resources') because the KSP-skip
+        # optimization left path_link_array as a None placeholder that the (skipped)
+        # modulation-aware call was expected to fill.
+        settings = settings_vone_4node()
+        assert "path_sort_criteria" not in settings  # must exercise the default
+        env, params = make(settings, log_wrapper=False)
+        self.assertIsNotNone(params.path_link_array)
+
+
+class VoneRLSmokeTest(chex.TestCase):
+    """End-to-end smoke tests for VONE RL action selection and the PPO loss.
+
+    Regression tests for: missing VONEEnv.action_mask (AttributeError at rollout time),
+    per-head masks being added to the full unsliced logits (broadcast error), the same
+    RNG key being reused for the source/path/dest samples, and the formatted slot request
+    leaking into the carried state via action_mask_slots (crashing the subsequent step).
+    """
+
+    def setUp(self):
+        super().setUp()
+        import optax
+        from box import Box
+
+        from xlron.train.train_utils import TrainState, init_network
+
+        settings = settings_vone_4node()
+        self.env, self.params = make(settings)  # LogWrapper-wrapped, as in training
+        self.config = Box(
+            dict(
+                env_type="vone",
+                USE_GNN=False,
+                USE_TRANSFORMER=False,
+                deterministic=False,
+                include_no_op=False,
+                ACTIVATION="tanh",
+                NUM_LAYERS=2,
+                NUM_UNITS=16,
+                mlp_layer_norm=False,
+                ACTION_DIM=self.env.num_actions(self.params),
+                INPUT_DIM=int(self.env.observation_space(self.params).n),
+            )
+        )
+        model = init_network(self.config, jax.random.PRNGKey(1))
+        self.train_state = TrainState.create(model=model, tx=optax.sgd(1e-3))
+
+    def _rollout(self, num_steps):
+        from xlron.train.train_utils import select_action
+
+        rng = jax.random.PRNGKey(2)
+        rng, reset_key = jax.random.split(rng)
+        obs, env_state = self.env.reset(reset_key, self.params)
+        last_obs = tuple([obs])
+        transitions = []
+        for _ in range(num_steps):
+            rng, action_key = jax.random.split(rng)
+            env_state, action, log_prob, value = select_action(
+                (action_key, env_state, last_obs),
+                self.env,
+                self.params,
+                self.train_state,
+                self.config,
+            )
+            inner = env_state.env_state
+            obs, env_state, reward, terminal, truncated, info = self.env.step(
+                action_key, env_state, action, self.params
+            )
+            transitions.append(
+                (last_obs[0], action, log_prob, value, reward, terminal, truncated, inner)
+            )
+            last_obs = tuple([obs])
+        return transitions, env_state
+
+    def test_select_action_and_step(self):
+        num_nodes = self.params.num_nodes
+        path_dim = self.config.ACTION_DIM - 2 * num_nodes
+        transitions, env_state = self._rollout(10)
+        for _, action, log_prob, value, *_ in transitions:
+            chex.assert_shape(action, (3,))
+            # Each head's action must lie within its own head's range
+            self.assertTrue(0 <= int(action[0]) < num_nodes)
+            self.assertTrue(0 <= int(action[1]) < path_dim)
+            self.assertTrue(0 <= int(action[2]) < num_nodes)
+            self.assertTrue(bool(jnp.isfinite(log_prob)))
+            self.assertTrue(bool(jnp.isfinite(value)))
+        # The VONE request array layout must survive masking + stepping
+        chex.assert_shape(
+            env_state.env_state.request_array,
+            (2, self.params.max_edges * 2 + 1),  # ty: ignore[unresolved-attribute]
+        )
+
+    def test_ppo_loss_per_head_masking(self):
+        import equinox as eqx
+        from box import Box
+
+        from xlron.train.ppo import _loss_fn
+
+        transitions, _ = self._rollout(8)
+        obs = jnp.stack([t[0] for t in transitions])
+        actions = jnp.stack([t[1] for t in transitions])
+        log_probs = jnp.stack([t[2] for t in transitions])
+        values = jnp.stack([t[3] for t in transitions])
+        rewards = jnp.stack([t[4] for t in transitions])
+        terminals = jnp.stack([t[5] for t in transitions])
+        truncateds = jnp.stack([t[6] for t in transitions])
+        mask_s = jnp.stack([t[7].node_mask_s for t in transitions])
+        mask_p = jnp.stack([t[7].link_slot_mask for t in transitions])
+        mask_d = jnp.stack([t[7].node_mask_d for t in transitions])
+        valid_mass = jnp.stack([t[7].valid_mass for t in transitions])
+        traj_batch = VONETransition(
+            terminals,
+            truncateds,
+            actions,
+            values,
+            rewards,
+            log_probs,
+            tuple([obs]),
+            {},
+            mask_s,
+            mask_p,
+            mask_d,
+            valid_mass,
+            mask_p,
+        )
+        batch = len(transitions)
+        loss_config = Box(
+            dict(
+                env_type="vone",
+                USE_GNN=False,
+                USE_TRANSFORMER=False,
+                OFF_POLICY_IAM=False,
+                LOGR_CLIP=10.0,
+                RHO_CLIP=0.0,
+                C_CLIP=0.0,
+                IAM_GATING=False,
+                IAM_DAMPING=False,
+                ADV_CLIP=10.0,
+                CLIP_EPS=0.2,
+                VF_COEF=0.5,
+                VALID_MASS_LOSS_COEF=0.1,
+                DEBUG=False,
+                DEBUG_LOSS=False,
+                ENHANCED_LOGGING=False,
+                ORDERED=False,
+            )
+        )
+        model = eqx.combine(self.train_state.model_params, self.train_state.model_static)
+        adv = jnp.ones(batch)
+        targets = jnp.zeros(batch)
+        importance_weights = jnp.ones(batch)
+        (total_loss, aux), grads = _loss_fn(
+            model, self.train_state, (traj_batch, adv, targets, importance_weights), loss_config
+        )
+        self.assertTrue(bool(jnp.isfinite(total_loss)))
+        for leaf in jax.tree_util.tree_leaves(eqx.filter(grads, eqx.is_inexact_array)):
+            self.assertTrue(bool(jnp.all(jnp.isfinite(leaf))))
 
 
 if __name__ == "__main__":

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -465,16 +465,23 @@ def _loss_fn(
     # HANDLE DIFFERENT ACTION TYPES FOR OPTICAL NETWORKS
     recenter_clip = False  # only the standard off-policy IAM branch below recenters the clip
     if config.env_type.lower() == "vone":
-        # VONE: source, path, destination actions
+        # VONE: source, path, destination actions. Slice the logits into per-head blocks
+        # ([source nodes | dest nodes | path-slot actions]) exactly as in select_action,
+        # so the PPO ratio compares like-for-like per-head log probs.
         vone_batch = cast(VONETransition, traj_batch)
+        num_nodes = vone_batch.action_mask_s.shape[-1]
+        path_dim = vone_batch.action_mask_p.shape[-1]
+        source_logits = pi._logits[..., :num_nodes]
+        dest_logits = pi._logits[..., num_nodes : 2 * num_nodes]
+        path_logits = pi._logits[..., 2 * num_nodes : 2 * num_nodes + path_dim]
         pi_source = distrax.Categorical(
-            logits=pi._logits + (-1e8 * (1 - vone_batch.action_mask_s.astype(jnp.float32)))
+            logits=source_logits + (-1e8 * (1 - vone_batch.action_mask_s.astype(jnp.float32)))
         )
         pi_path = distrax.Categorical(
-            logits=pi._logits + (-1e8 * (1 - vone_batch.action_mask_p.astype(jnp.float32)))
+            logits=path_logits + (-1e8 * (1 - vone_batch.action_mask_p.astype(jnp.float32)))
         )
         pi_dest = distrax.Categorical(
-            logits=pi._logits + (-1e8 * (1 - vone_batch.action_mask_d.astype(jnp.float32)))
+            logits=dest_logits + (-1e8 * (1 - vone_batch.action_mask_d.astype(jnp.float32)))
         )
         action_s = traj_batch.action[:, 0]
         action_p = traj_batch.action[:, 1]
@@ -635,9 +642,13 @@ def _loss_fn(
     if config.VALID_MASS_LOSS_COEF > 0:
         # Recompute valid mass from *current* logits so gradients flow back
         if config.env_type.lower() == "vone":
-            current_probs = jax.nn.softmax(pi._logits, axis=-1)
+            vone_batch = cast(VONETransition, traj_batch)
+            num_nodes = vone_batch.action_mask_s.shape[-1]
+            path_dim = vone_batch.action_mask_p.shape[-1]
+            path_logits = pi._logits[..., 2 * num_nodes : 2 * num_nodes + path_dim]
+            current_probs = jax.nn.softmax(path_logits, axis=-1)
             current_valid_mass = jnp.sum(
-                current_probs * cast(VONETransition, traj_batch).action_mask_p, axis=-1
+                current_probs * vone_batch.action_mask_p.astype(jnp.float32), axis=-1
             )
         elif config.env_type.lower() == "rsa_gn_model" and config.launch_power_type == "rl":
             current_probs = jax.nn.softmax(pi[0]._logits, axis=-1)

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -964,48 +964,50 @@ def select_action(select_action_state, env, env_params, train_state, config):
 
     # Always do action masking with VONE
     if config.env_type.lower() == "vone":
-        # TODO - change this to work with single set of logits (probably just slice them)
-        vmap_mask_nodes = jax.vmap(env.action_mask_nodes, in_axes=(0, None))
-        vmap_mask_slots = jax.vmap(env.action_mask_slots, in_axes=(0, None, 0))
-        vmap_mask_dest_node = jax.vmap(env.action_mask_dest_node, in_axes=(0, None, 0))
+        # The single set of logits is sliced into three heads. Layout matches
+        # VONEEnv.num_actions: [source nodes | dest nodes | path-slot actions]
+        # (a trailing no-op logit, if include_no_op, belongs to no head).
+        # select_action operates on a single (unbatched) env state; batching over
+        # NUM_ENVS is applied by the outer vmap of _env_step in ppo.py.
+        num_nodes = env_params.num_nodes
+        source_logits = pi._logits[..., :num_nodes]
+        dest_logits = pi._logits[..., num_nodes : 2 * num_nodes]
+        key_s, key_p, key_d = jax.random.split(action_key, 3)
 
-        env_state = env_state.replace(env_state=vmap_mask_nodes(env_state.env_state, env_params))
+        inner_state = env.action_mask_nodes(env_state.env_state, env_params)
         pi_source = distrax.Categorical(
-            logits=pi._logits + (-1e8 * (1 - env_state.env_state.node_mask_s.astype(jnp.float32)))
+            logits=source_logits + (-1e8 * (1 - inner_state.node_mask_s.astype(jnp.float32)))
         )
-
-        action_s = (
-            pi_source.sample(seed=action_key) if not config.deterministic else pi_source.mode()
-        )
+        action_s = pi_source.sample(seed=key_s) if not config.deterministic else pi_source.mode()
 
         # Update destination mask now source has been selected
-        env_state = env_state.replace(
-            env_state=vmap_mask_dest_node(env_state.env_state, env_params, action_s)
-        )
+        inner_state = env.action_mask_dest_node(inner_state, env_params, action_s)
         pi_dest = distrax.Categorical(
-            logits=pi._logits + (-1e8 * (1 - env_state.env_state.node_mask_d.astype(jnp.float32)))
+            logits=dest_logits + (-1e8 * (1 - inner_state.node_mask_d.astype(jnp.float32)))
         )
+        action_d = pi_dest.sample(seed=key_d) if not config.deterministic else pi_dest.mode()
 
-        action_p = jnp.full(action_s.shape, 0)
-        action_d = pi_dest.sample(seed=action_key) if not config.deterministic else pi_dest.mode()
-        action = jnp.stack((action_s, action_p, action_d), axis=1)
-
-        env_state = env_state.replace(
-            env_state=vmap_mask_slots(env_state.env_state, env_params, action)
-        )
+        action = jnp.stack((action_s, jnp.zeros_like(action_s), action_d))
+        inner_state = env.action_mask_slots(inner_state, env_params, action)
+        path_dim = inner_state.link_slot_mask.shape[-1]
+        path_logits = pi._logits[..., 2 * num_nodes : 2 * num_nodes + path_dim]
         pi_path = distrax.Categorical(
-            logits=pi._logits
-            + (-1e8 * (1 - env_state.env_state.link_slot_mask.astype(jnp.float32)))
+            logits=path_logits + (-1e8 * (1 - inner_state.link_slot_mask.astype(jnp.float32)))
         )
-        action_p = pi_path.sample(seed=action_key) if not config.deterministic else pi_path.mode()
-        action = jnp.stack((action_s, action_p, action_d), axis=1)
+        action_p = pi_path.sample(seed=key_p) if not config.deterministic else pi_path.mode()
+        action = jnp.stack((action_s, action_p, action_d))
 
         log_prob_source = pi_source.log_prob(action_s)
         log_prob_path = pi_path.log_prob(action_p)
         log_prob_dest = pi_dest.log_prob(action_d)
         log_prob = log_prob_dest + log_prob_path + log_prob_source
-        probs = jax.nn.softmax(pi._logits, axis=-1)
-        valid_mass = jnp.sum(probs * action_mask, axis=-1)
+        env_state = env_state.replace(env_state=inner_state)
+        # Overwrite the (stale) pre-branch masks with the freshly computed path masks so the
+        # final state update below stores them; valid_mass mirrors the RSA path-head semantics.
+        action_mask = inner_state.link_slot_mask
+        full_action_mask = inner_state.full_link_slot_mask
+        probs = jax.nn.softmax(path_logits, axis=-1)
+        valid_mass = jnp.sum(probs * action_mask.astype(jnp.float32), axis=-1)
 
     elif "gn_model" in config.env_type.lower() and config.launch_power_type == "rl":
         pi_masked = distrax.Categorical(


### PR DESCRIPTION
## Summary

The VONE environment has been broken for a while (its test module was skipped with "VONE tests are currently disabled in CI"). This PR fixes six independent defects so VONE works as a coherent whole — `make()`, environment stepping, action masking, and RL training all run end to end — and re-enables `vone_test.py` with regression tests for each fix.

## Fixes

### 1. `make()` crashed for VONE with the default path sort (`xlron/environments/make_env.py`)
The KSP-skip optimization's predicate treated `vone` as modulation-aware, so with the default `path_sort_criteria='spectral_resources'` the first `init_path_link_array` call was skipped, leaving `path_link_array = None`. But `vone` with `slot_size == 1` sets `consider_modulation_format = False`, so the modulation-aware second call never ran and `jnp.array(None)` raised `ValueError`. VONE environments could not be created at all with default settings. The predicate now mirrors the `consider_modulation_format` derivation (and the first call correctly uses the KSP cache).

### 2. VONE RL action selection could not run (`xlron/train/train_utils.py`, `xlron/environments/vone/vone.py`)
- `select_action` unconditionally calls `env.action_mask(...)`, which `VONEEnv` did not define → `AttributeError` at trace time for every VONE RL run. `VONEEnv.action_mask` is added (returns the stored path masks, API parity with RSA-family envs).
- The per-head masks (`num_nodes` / `num_nodes` / `k*ceil(S/agg)` wide) were added to the **full unsliced** logits (`2*num_nodes + path_dim` wide) — a guaranteed broadcast error. The logits are now sliced into per-head blocks with a documented layout: `[source nodes | dest nodes | path-slot actions]`, matching `VONEEnv.num_actions` (a trailing no-op logit belongs to no head).
- The branch internally `jax.vmap`-ed the mask functions — a leftover from before `_env_step` itself was vmapped over `NUM_ENVS`; `select_action` operates on a single env state, so the vmaps are removed.
- The same `action_key` was reused to sample source, dest, and path, correlating the three draws; it is now split into three subkeys.
- `valid_mass` is computed from the path head (previously another shape mismatch against the full-logits softmax).

### 3. PPO loss used the same unsliced logits (`xlron/train/ppo.py`)
`_loss_fn`'s VONE branch applied `action_mask_s/p/d` to the full logits. It now slices per head identically to `select_action` so the PPO ratio compares like-for-like per-head log probs; the `VALID_MASS_LOSS_COEF` recompute uses the same path-head slice.

### 4. `mask_nodes` crashed under jit on real states (`xlron/environments/vone/vone_funcs.py`)
`action_history` is float (`LARGE_FLOAT_DTYPE`), but `mask_previous_selections` passed its entries directly as `dynamic_update_slice_in_dim` start indices → `TypeError` at trace time for any env-created state (old fixtures hand-built int arrays, masking the bug). Indices are now cast to `INDEX_DTYPE` at the use site; the stored dtype is unchanged to keep the `lax.scan` carry stable.

### 5. `undo_link_action_vone` freed active services' spectrum (`xlron/environments/vone/vone_funcs.py`)
On VNR rejection, the undo zeroed masked slots' departure times. If a tentative lightpath had collided with a previously **finalised** service, that service's positive departure time was destroyed, and `remove_expired_services_rsa` released its spectrum on the very next request — phantom capacity and inconsistent state. The undo now adds back the tentative departure delta (`current_time + holding_time`, still the failing request's values at undo time), mirroring `complete_step_rsa`: free-slot tentatives restore to 0, collision slots restore their true departure.

### 6. `check_topology` rejected zero-padded patterns (`xlron/environments/vone/vone_funcs.py`)
With mixed-length `--virtual_topologies` (e.g. `3_bus,3_ring`), shorter patterns are zero-padded; padding positions keep the `-1` sentinel in `check_virtual`, and `jnp.any(check)` counted `-1` as truthy — every valid embedding of a shorter pattern was rejected (silent 100% blocking for that VNR class). Changed to `jnp.any(check > 0)`; the physical-side loop already self-cleans and needs no change.

### API parity (`xlron/environments/vone/vone.py`)
`VONEEnv` predated the current env API: `reset`/`reset_env` now accept the optional `state` argument (LogWrapper passes it), and `step_env` stashes `_accepted_services` / `_accepted_bitrate` / `_total_bitrate` / `_utilisation` in `info` so `LogWrapper.step` can pop them (previously `KeyError`).

## Tests

- Removed the module-level `pytest.skip` from `xlron/environments/vone/vone_test.py`; all 443 tests pass.
- New regression tests, each failing before its fix:
  - `VoneMakeTest.test_make_vone_default_path_sort` (fix 1)
  - `VoneRLSmokeTest.test_select_action_and_step` — real MLP through `select_action` + LogWrapper `env.step` for 10 steps: per-head action ranges, finite log probs, request-array layout preserved (fixes 2, and the `action_mask_slots` leak)
  - `VoneRLSmokeTest.test_ppo_loss_per_head_masking` — `_loss_fn` on a collected `VONETransition` batch: finite loss and gradients (fix 3)
  - `MaskNodesTest.test_mask_nodes_env_native_action_history` (fix 4)
  - `UndoLinkActionVoneTest.test_undo_restores_preexisting_departures` (fix 5)
  - `CheckTopologyTest.test_check_topology_mixed_length_patterns` — padded valid / virtual-clash / physical-clash + full-length control (fix 6)
  - `VoneActionMaskTest` now asserts `request_array` is unchanged after `action_mask_slots`
- End-to-end CLI check: a tiny VONE training run (`--env_type=vone --topology_name=4node`, 400 steps, 2 envs) compiles and trains with sensible metrics.
- Also green: `ppo_test.py`, `make_env_test.py`, `env_funcs_test.py`. Five `ty: ignore[unresolved-attribute]` suppressions in `gn_model_test.py` / `rwa_lightpath_reuse_test.py` became obsolete once `VONEEnv` gained `action_mask` and were removed.

## Behavior changes

- **VONE works again.** Every prior entry point crashed, so there is no comparable baseline; any saved VONE model predating this PR is incompatible with the new per-head logit layout.
- Mixed-length `--virtual_topologies` configs will show lower (correct) blocking: shorter patterns were previously always rejected.
- Utilisation/blocking under contention will be slightly higher (correct): rejected VNRs no longer free colliding active services' spectrum early.
- VONE episode metrics (accepted services/bitrate, utilisation) are now populated in LogWrapper output.
- `vone_test.py` runs in CI again (~40s single-threaded).

---
*Part of a 13-PR batch from an automated multi-agent codebase review (each finding independently adversarially verified, each diff reviewed, full test suite green per branch). Sibling PRs may touch adjacent lines; expect occasional rebases as they merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)