### PR TITLE
Fix env reward/terminal bugs, warmup-biased metrics, and action-logging fields

### DIFF
--- a/xlron/environments/env_funcs.py
+++ b/xlron/environments/env_funcs.py
@@ -1533,7 +1533,9 @@ def generate_arrival_holding_times(key, params, arrival_rate, mean_service_holdi
     )  # Divide because it is rate (lambda)
     if params.truncate_holding_time:
         # For DeepRMSA, need to generate holding times that are less than 2*mean_service_holding_time
-        key_holding = jax.random.split(key, 5)
+        # Split the child key (not the parent): split(key, 5)[:2] == split(key, 2), so
+        # re-splitting the parent would alias candidate keys with key_arrival
+        key_holding = jax.random.split(key_holding, 5)
         holding_times = jax.vmap(
             lambda x: jax.random.exponential(x, shape=(1,), dtype=dtype_config.TIME_DTYPE)
             * mean_service_holding_time

--- a/xlron/environments/env_funcs_test.py
+++ b/xlron/environments/env_funcs_test.py
@@ -297,6 +297,22 @@ class GenerateArrivalHoldingTimesTest(chex.TestCase):
         chex.assert_trees_all_close(arrival_time, expected[0])
         chex.assert_trees_all_close(holding_time, expected[1])
 
+    def test_truncated_holding_time_independent_of_arrival_time(self):
+        """Regression test: with truncate_holding_time, the candidate holding-time keys
+        were re-split from the parent key, so (split being prefix-stable) candidate 0
+        reused key_arrival. When candidates 1-4 were all truncated, the holding time was
+        the same exponential draw as the arrival time (perfectly correlated).
+        """
+        _, _, _, _, params = rwa_4node_test_setup(truncate_holding_time=True)
+        keys = jax.random.split(jax.random.PRNGKey(42), 50000)
+        # With rate == mean == 1, an aliased draw makes holding_time == arrival_time exactly
+        arrival, holding = jax.vmap(generate_arrival_holding_times, in_axes=(0, None, None, None))(
+            keys, params, jnp.array(1.0), jnp.array(1.0)
+        )
+        arrival, holding = arrival.reshape(-1), holding.reshape(-1)
+        aliased = jnp.sum((holding == arrival) & (holding > 0))
+        self.assertEqual(int(aliased), 0)
+
 
 class SetPathLinksTest(chex.TestCase):
     def setUp(self):

--- a/xlron/environments/gn_model/gn_model_test.py
+++ b/xlron/environments/gn_model/gn_model_test.py
@@ -1348,6 +1348,138 @@ class GetPathsObsGNModelTest(chex.TestCase):
         self.assertLess(float(jnp.max(jnp.abs(obs[4:]))), 1e3)
 
 
+def rmsa_gn_model_mod_format_reward_test_setup():
+    return _gn_cached_setup(
+        "rmsa_gn_model_mod_format_reward",
+        dict(
+            k=4,
+            topology_name="nsfnet_deeprmsa_directed",
+            link_resources=10,
+            max_requests=100,
+            values_bw=[100],
+            incremental_loading=True,
+            env_type="rmsa_gn_model",
+            slot_size=12.5,
+            guardband=0,
+            mod_format_correction=False,
+            max_power_per_fibre=10.0,
+            coherent=False,
+            include_no_op=False,
+            reward_type="mod_format",
+        ),
+        seed=3,
+    )
+
+
+class ModFormatRewardTest(chex.TestCase):
+    """Regression test: reward_type='mod_format' used to assert RSAGNModelEnvParams but
+    read modulation_format_index_array, which only exists on RMSAGNModelEnvState, so it
+    failed at trace time in every configuration.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = (
+            rmsa_gn_model_mod_format_reward_test_setup()
+        )
+
+    def test_step_traces_and_returns_finite_reward(self):
+        rng, rng_sample, rng_step = jax.random.split(self.key, 3)
+        mask, _, mod_format_mask = self.env.action_mask(self.state, self.params)
+        state = self.state.replace(link_slot_mask=mask, mod_format_mask=mod_format_mask)
+        action_dist = distrax.Categorical(logits=jnp.where(mask > 0, 0.0, -1e8))
+        path_action = action_dist.sample(seed=rng_sample)
+        power_action = jnp.array([0])
+        action = jnp.concatenate([path_action.reshape((1,)), power_action.reshape((1,))], axis=0)
+        obs, new_state, reward, terminal, truncated, info = self.env.step(
+            rng_step, state, action, self.params
+        )
+        self.assertTrue(bool(jnp.isfinite(reward)))
+
+
+def rsa_gn_model_log_actions_test_setup():
+    # Not via _gn_cached_setup, which forces log_wrapper=False: this test targets LogWrapper
+    key = jax.random.PRNGKey(0)
+    if "rsa_gn_model_log_actions" not in _gn_cache:
+        settings = dict(
+            k=5,
+            topology_name="nsfnet_deeprmsa_undirected",
+            link_resources=10,
+            max_requests=100,
+            values_bw=[100],
+            env_type="rsa_gn_model",
+            interband_gap=0,
+            slot_size=25,
+            mod_format_correction=False,
+            launch_power=0.0,
+            load=100,
+            mean_service_holding_time=10,
+            log_actions=True,
+            relative_arrival_times=False,
+        )
+        env, params = make(settings, log_wrapper=True)
+        _gn_cache["rsa_gn_model_log_actions"] = (env, params)
+    env, params = _gn_cache["rsa_gn_model_log_actions"]
+    obs, state = env.reset(key, params)
+    return key, env, obs, state, params
+
+
+class LogWrapperActionLoggingTest(chex.TestCase):
+    """Regression tests for LogWrapper's log_actions fields.
+
+    path_snr used to be looked up with the k-relative path index (missing the
+    node-pair offset into path_link_array), and arrival/departure times were read
+    from the post-step state, i.e. from the NEXT request.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = (
+            rsa_gn_model_log_actions_test_setup()
+        )
+
+    def test_path_snr_and_times_describe_acting_request(self):
+        params = self.params
+        pre_state = self.state.env_state
+        # Pre-step values (read before step: the acting request's fields are
+        # overwritten by generate_request inside step_env)
+        nodes_sd, _ = read_rsa_request(pre_state.request_array)
+        source, dest = nodes_sd
+        i = int(
+            get_path_indices(
+                params,
+                source,
+                dest,
+                params.k_paths,
+                params.num_nodes,
+                directed=params.directed_graph,
+            )
+        )
+        # Sanity: the request is not for the first node pair, so the missing
+        # offset would have selected the wrong path row before the fix
+        self.assertGreater(i, 0)
+        expected_arrival = float(pre_state.current_time[0])
+        expected_departure = float(pre_state.current_time[0] + pre_state.holding_time[0])
+        # Select k-index 1, slot 0 (aggregate_slots=1 => action = k_index * link_resources)
+        k_index = 1
+        path_action = jnp.array(k_index * params.link_resources, dtype=jnp.float32)
+        action = jnp.stack([path_action, jnp.array(0.0, dtype=jnp.float32)])
+
+        rng, step_key = jax.random.split(self.key)
+        obs, log_state, reward, terminal, truncated, info = self.env.step(
+            step_key, self.state, action, params
+        )
+
+        expected_path = params.path_link_array.val[i + k_index]
+        expected_snr = get_snr_for_path(expected_path, log_state.env_state.link_snr_array, params)[
+            0
+        ]
+        chex.assert_trees_all_close(info["path_snr"], expected_snr)
+        self.assertEqual(int(info["path_index"]), i + k_index)
+        self.assertAlmostEqual(float(info["arrival_time"]), expected_arrival, places=5)
+        self.assertAlmostEqual(float(info["departure_time"]), expected_departure, places=4)
+
+
 if __name__ == "__main__":
     jax.config.update("jax_numpy_rank_promotion", "raise")
     absltest.main()

--- a/xlron/environments/rsa/rsa.py
+++ b/xlron/environments/rsa/rsa.py
@@ -1313,29 +1313,17 @@ class RSAEnv(environment.Environment):
             reward: Reward for failure
         """
         reward = -one
+        # Use action_info.requested_datarate (captured in process_action before the
+        # request is regenerated) rather than state.request_array, so the value is
+        # identical at both call sites: calculate_reward (pre-mutation state) and
+        # is_terminal for end_first_blocking (post-generate_request state).
         if params.reward_type == "service":
             pass
         elif params.reward_type == "bitrate":
-            reward = (
-                differentiable_index(
-                    state.request_array,
-                    1,
-                    temperature=params.temperature,
-                    differentiable=params.differentiable,
-                )
-                * reward
-                / jnp.max(params.values_bw.val)
-            )
+            reward = action_info.requested_datarate * reward / jnp.max(params.values_bw.val)
         else:
             reward = (
-                reward
-                * differentiable_index(
-                    read_rsa_request(state.request_array),
-                    1,
-                    temperature=params.temperature,
-                    differentiable=params.differentiable,
-                )
-                / jnp.max(params.values_bw.val)
+                reward * action_info.requested_datarate / jnp.max(params.values_bw.val)
                 if params.maximise_throughput
                 else reward
             )
@@ -1358,7 +1346,7 @@ class RSAEnv(environment.Environment):
         reward = zero
 
         if params.reward_type != "service":
-            reward = state.request_array[1] * reward / jnp.max(params.values_bw.val)
+            reward = action_info.requested_datarate * one / jnp.max(params.values_bw.val)
             if params.reward_type == "bitrate":
                 pass  # No additional calculation needed
             elif params.reward_type == "snr":
@@ -1375,7 +1363,8 @@ class RSAEnv(environment.Environment):
                 return reward + path_snr_norm
             elif params.reward_type == "mod_format":
                 # Modulation format calculation...
-                assert params.__class__.__name__ == "RSAGNModelEnvParams"
+                # modulation_format_index_array only exists on RMSAGNModelEnvState
+                assert params.__class__.__name__ == "RMSAGNModelEnvParams"
                 rmsa_state = cast(RMSAGNModelEnvState, state)
                 mod_format_index = get_path_slots(
                     rmsa_state.modulation_format_index_array,

--- a/xlron/environments/rsa/rsa_test.py
+++ b/xlron/environments/rsa/rsa_test.py
@@ -707,6 +707,81 @@ class RsaActionMaskTest(chex.TestCase):
         chex.assert_trees_all_close(link_slot_mask, expected)
 
 
+class RewardTypeBitrateTest(chex.TestCase):
+    """Regression tests for reward_type='bitrate'.
+
+    The success reward was previously zeroed by multiplying the bitrate by the
+    zero-initialised reward, so a successful step returned 0 while a failure
+    returned -bitrate/max(values_bw) (asymmetric, no positive reinforcement).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = rsa_4node_3_slot_request_test_setup(
+            reward_type="bitrate"
+        )
+
+    @chex.all_variants()
+    def test_success_reward_is_normalised_bitrate(self):
+        # values_bw=[3], so a successful placement gives 3 / max([3]) = 1.0
+        obs, state, reward, done, truncated, info = self.variant(
+            self.env.step, static_argnums=(3,)
+        )(self.key, self.state, jnp.array(0), self.params)
+        chex.assert_trees_all_close(reward, jnp.array(1.0, dtype=reward.dtype))
+
+    @chex.all_variants()
+    def test_failure_reward_is_negative_normalised_bitrate(self):
+        # Force a blocked action by filling the network
+        state = self.state.replace(link_slot_array=jnp.ones_like(self.state.link_slot_array))
+        obs, state, reward, done, truncated, info = self.variant(
+            self.env.step, static_argnums=(3,)
+        )(self.key, state, jnp.array(0), self.params)
+        chex.assert_trees_all_close(reward, jnp.array(-1.0, dtype=reward.dtype))
+
+
+class EndFirstBlockingBitrateTest(chex.TestCase):
+    """Regression test: with end_first_blocking + reward_type='bitrate', is_terminal
+    used to compare the reward against the failure reward of the NEXT request (the
+    request array is regenerated before is_terminal runs), so blocked steps were not
+    terminal whenever consecutive request bitrates differed.
+    """
+
+    def setUp(self):
+        super().setUp()
+        settings = settings_rwa_4node()
+        settings.update(
+            env_type="rsa",
+            values_bw=[1, 3],
+            link_resources=5,
+            incremental_loading=True,
+            end_first_blocking=True,
+            reward_type="bitrate",
+        )
+        self.key = jax.random.PRNGKey(0)
+        self.env, self.params = make(settings, log_wrapper=False)
+        self.obs, self.state = self.env.reset(self.key, self.params)
+
+    def test_blocked_step_is_terminal(self):
+        step = jax.jit(self.env.step, static_argnums=(3,))
+        state = self.state
+        rng = self.key
+        bitrates = []
+        for _ in range(10):
+            rng, key_step = jax.random.split(rng)
+            # Force every action to be blocked by filling the network
+            state = state.replace(link_slot_array=jnp.ones_like(state.link_slot_array))
+            # Read the current bitrate before stepping (step donates state buffers)
+            bitrates.append(float(state.request_array[1]))
+            obs, state, reward, done, truncated, info = step(
+                key_step, state, jnp.array(0), self.params
+            )
+            self.assertLess(float(reward), 0.0)
+            self.assertTrue(bool(done), "Blocked step must terminate with end_first_blocking")
+        # Sanity: the traffic contains different bitrates, so the pre-fix behavior
+        # (terminal only when consecutive bitrates match) would have failed above
+        self.assertGreater(len(set(bitrates)), 1)
+
+
 if __name__ == "__main__":
     jax.config.update("jax_numpy_rank_promotion", "raise")
     absltest.main()

--- a/xlron/environments/wrappers.py
+++ b/xlron/environments/wrappers.py
@@ -64,6 +64,10 @@ class LogWrapper(GymnaxWrapper):
         action: Union[int, float] | Tuple[Union[int, float], Union[int, float]],
         params: RSAEnvParams,
     ) -> Tuple[Array, LogEnvState, float, bool, bool, dict]:
+        # Keep the pre-step state: the action/request fields logged below must describe
+        # the request the action was taken for, but step_env's generate_request replaces
+        # request_array/current_time/holding_time with the next request's values
+        prev_env_state = log_state.env_state
         obs, env_state, reward, terminal, truncated, info = self._env.step(
             key, log_state.env_state, action, params
         )
@@ -110,8 +114,8 @@ class LogWrapper(GymnaxWrapper):
 
         # Now, if we need to log actions OR we have RSA params, compute the common fields
         if is_gn_params or params.log_actions:
-            # Compute common fields
-            nodes_sd, dr_request = read_rsa_request(log_state.env_state.request_array)
+            # Compute common fields from the pre-step state (see prev_env_state above)
+            nodes_sd, dr_request = read_rsa_request(prev_env_state.request_array)
             source, dest = nodes_sd
             i = get_path_indices(
                 params,
@@ -121,7 +125,7 @@ class LogWrapper(GymnaxWrapper):
                 params.num_nodes,
                 directed=params.directed_graph,
             ).astype(jnp.int32)
-            path_index, slot_index = process_path_action(log_state.env_state, params, action)
+            path_index, slot_index = process_path_action(prev_env_state, params, action)
 
             # Set common info
             info["path_index"] = i + path_index
@@ -138,13 +142,23 @@ class LogWrapper(GymnaxWrapper):
             if params.log_actions:
                 # RSA-specific logging
                 if is_gn_params:
-                    path = params.path_link_array.val[path_index.astype(jnp.int32)]
+                    # Index with the global path row (node-pair offset + k-index),
+                    # unpacking bits if the path-link array is bit-packed
+                    path_link_array = (
+                        jnp.unpackbits(params.path_link_array.val, axis=1)[:, : params.num_links]
+                        if params.pack_path_bits
+                        else params.path_link_array.val
+                    )
+                    path = path_link_array[(i + path_index).astype(jnp.int32)]
                     info["path_snr"] = get_snr_for_path(path, env_state.link_snr_array, params)[
                         slot_index.astype(jnp.int32)
                     ]
-                # Common logging fields
-                info["arrival_time"] = env_state.current_time[0]
-                info["departure_time"] = env_state.current_time[0] + env_state.holding_time[0]
+                # Common logging fields: use the pre-step state so the times belong to
+                # the request being logged (step_env's generate_request advances them)
+                info["arrival_time"] = prev_env_state.current_time[0]
+                info["departure_time"] = (
+                    prev_env_state.current_time[0] + prev_env_state.holding_time[0]
+                )
         return obs, log_state, reward, terminal, truncated, info
 
     def _tree_flatten(self) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -97,6 +97,13 @@ reward_centering_metrics = [
     "reward_centering/value_mean",
 ]
 
+# Prioritized experience replay diagnostics (always populated in loss_info by ppo.py)
+prioritization_metrics = [
+    "prioritization/beta",
+    "prioritization/priority_mean",
+    "prioritization/priority_std",
+]
+
 
 class LossDiagnostics(NamedTuple):
     """Per-step diagnostics emitted from the PPO loss when ENHANCED_LOGGING is on.
@@ -823,6 +830,31 @@ def _make_multi_transform_optimizer(config: Box, actor_lr_schedule, vf_lr_schedu
     return actor_optimizer, critic_optimizer
 
 
+def reset_warmup_metric_counters(env_state):
+    """Zero the metric counters accumulated during warmup.
+
+    With continuous_operation the env is never reset, so the cumulative counters
+    (accepted_services, accepted_bitrate, total_bitrate) and the LogWrapper's
+    lengths/cum_returns would otherwise include the near-zero-blocking network-fill
+    transient, biasing every logged blocking probability (ENV_WARMUP_STEPS is
+    documented as 'steps before collecting stats'). These fields are metrics-only;
+    total_requests, which drives episode truncation, is deliberately kept.
+    jnp.zeros_like preserves per-env shapes and dtypes for the jitted learner.
+    """
+    return env_state.replace(
+        lengths=jnp.zeros_like(env_state.lengths),
+        cum_returns=jnp.zeros_like(env_state.cum_returns),
+        accepted_services=jnp.zeros_like(env_state.accepted_services),
+        accepted_bitrate=jnp.zeros_like(env_state.accepted_bitrate),
+        total_bitrate=jnp.zeros_like(env_state.total_bitrate),
+        env_state=env_state.env_state.replace(
+            accepted_services=jnp.zeros_like(env_state.env_state.accepted_services),
+            accepted_bitrate=jnp.zeros_like(env_state.env_state.accepted_bitrate),
+            total_bitrate=jnp.zeros_like(env_state.env_state.total_bitrate),
+        ),
+    )
+
+
 def experiment_data_setup(config: Box, rng: chex.PRNGKey) -> Tuple:
     # INIT ENV
     env, env_params = make(config)
@@ -907,6 +939,9 @@ def experiment_data_setup(config: Box, rng: chex.PRNGKey) -> Tuple:
     warmup_fn = get_warmup_fn(warmup_state, env, env_params, runner_state, config)
     warmup_fn = jax.vmap(warmup_fn) if config.NUM_ENVS > 1 else warmup_fn
     env_state, obsv = warmup_fn(warmup_state)
+
+    if config.ENV_WARMUP_STEPS:
+        env_state = reset_warmup_metric_counters(env_state)
 
     # Initialise eval state
     init_runner_state = (runner_state, env_state, obsv, rng_step, rng_epoch)
@@ -1457,6 +1492,8 @@ def setup_wandb(config, project_name, experiment_name):
                 f"{metric}_episode_end_{agg}", step_metric="episode_count", summary="max"
             )
     for metric in loss_metrics:
+        wandb.define_metric(f"{metric}", step_metric="update_epoch")
+    for metric in prioritization_metrics:
         wandb.define_metric(f"{metric}", step_metric="update_epoch")
     # Register reward centering metrics if REWARD_CENTERING is enabled
     if config.get("REWARD_CENTERING", False):
@@ -2219,6 +2256,12 @@ def log_metrics(
                 print("Logging loss info")
                 for i in range(len(merged_out_loss["loss/total_loss"])):
                     log_dict = {f"{metric}": merged_out_loss[metric][i] for metric in loss_metrics}
+                    log_dict.update(
+                        {
+                            f"{metric}": merged_out_loss[metric][i]
+                            for metric in prioritization_metrics
+                        }
+                    )
                     if config.REWARD_CENTERING:
                         log_dict_rc = {
                             f"{metric}": merged_out_loss[metric][i]

--- a/xlron/train/train_utils_test.py
+++ b/xlron/train/train_utils_test.py
@@ -1,0 +1,105 @@
+"""Unit tests for train_utils.py helpers."""
+
+import jax
+import jax.numpy as jnp
+from absl.testing import absltest
+
+from xlron.environments.make_env import make
+from xlron.train import ppo
+from xlron.train.train_utils import (
+    diagnostics_metrics,
+    loss_metrics,
+    prioritization_metrics,
+    reset_warmup_metric_counters,
+    reward_centering_metrics,
+)
+
+
+class ResetWarmupMetricCountersTest(absltest.TestCase):
+    """Regression test: with continuous_operation the cumulative metric counters were
+    never reset after ENV_WARMUP_STEPS, so every logged blocking probability included
+    the near-zero-blocking network-fill transient.
+    """
+
+    def _stepped_log_state(self):
+        settings = dict(
+            env_type="rsa",
+            topology_name="4node",
+            k=2,
+            link_resources=5,
+            values_bw=[1],
+            slot_size=1,
+            guardband=0,
+            load=100,
+            mean_service_holding_time=10,
+            max_requests=10,
+            continuous_operation=True,
+        )
+        env, params = make(settings)  # LogWrapper-wrapped
+        key = jax.random.PRNGKey(0)
+        obs, state = env.reset(key, params)
+        step = jax.jit(env.step, static_argnums=(3,))
+        for _ in range(5):
+            key, step_key = jax.random.split(key)
+            obs, state, reward, terminal, truncated, info = step(
+                step_key, state, jnp.array(0), params
+            )
+        return state
+
+    def test_metric_counters_zeroed_and_total_requests_kept(self):
+        state = self._stepped_log_state()
+        # Counters have accumulated during the (simulated) warmup
+        self.assertGreater(int(state.lengths), 0)
+        self.assertGreater(int(state.env_state.total_bitrate), 0)
+        total_requests_before = int(state.env_state.total_requests)
+        self.assertGreater(total_requests_before, 0)
+
+        new_state = reset_warmup_metric_counters(state)
+
+        for field in (
+            "lengths",
+            "cum_returns",
+            "accepted_services",
+            "accepted_bitrate",
+            "total_bitrate",
+        ):
+            self.assertEqual(float(getattr(new_state, field)), 0.0, f"LogEnvState.{field}")
+        for field in ("accepted_services", "accepted_bitrate", "total_bitrate"):
+            self.assertEqual(float(getattr(new_state.env_state, field)), 0.0, f"env.{field}")
+        # total_requests drives episode truncation and must be preserved
+        self.assertEqual(int(new_state.env_state.total_requests), total_requests_before)
+
+    def test_shapes_and_dtypes_preserved(self):
+        state = self._stepped_log_state()
+        new_state = reset_warmup_metric_counters(state)
+        old_leaves = jax.tree_util.tree_leaves(state)
+        new_leaves = jax.tree_util.tree_leaves(new_state)
+        self.assertEqual(len(old_leaves), len(new_leaves))
+        for old, new in zip(old_leaves, new_leaves):
+            self.assertEqual(jnp.shape(old), jnp.shape(new))
+            self.assertEqual(jnp.asarray(old).dtype, jnp.asarray(new).dtype)
+
+
+class LossInfoMetricRegistrationTest(absltest.TestCase):
+    """Every key that _update_step puts in loss_info must be in one of the registered
+    wandb metric lists, otherwise it is computed but silently dropped from logging
+    (see CLAUDE.md 'Adding New Loss/Diagnostic Metrics').
+    """
+
+    def test_loss_info_keys_are_registered(self):
+        import inspect
+
+        source = inspect.getsource(ppo)
+        registered = set(
+            loss_metrics + prioritization_metrics + reward_centering_metrics + diagnostics_metrics
+        )
+        for prefix in ("loss/", "prioritization/", "reward_centering/"):
+            for line in source.splitlines():
+                line = line.strip()
+                if line.startswith(f'"{prefix}'):
+                    key = line.split('"')[1]
+                    self.assertIn(key, registered, f"loss_info key {key} not registered")
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
## Summary

Fixes six confirmed bugs (plus one optional PRNG hygiene fix) in the RSA env reward path, metrics pipeline, and LogWrapper action logging.

## Fixes

### 1. Non-service success rewards were always zero (`xlron/environments/rsa/rsa.py`)
`get_reward_success` initialised `reward = zero` and then computed `state.request_array[1] * reward / max(values_bw)` — multiplying by the zero it just assigned. This was a mechanical `1.0 -> reward` regression from the mixed-precision refactor (commit 0262809). `reward_type=bitrate` therefore gave 0 on success and `-bitrate/max` on failure (no positive reinforcement), and the `snr`/`mod_format` rewards silently lost their bitrate base term. Restored using `action_info.requested_datarate * one / max(values_bw)`.

### 2. `end_first_blocking` compared against the NEXT request's failure reward (`rsa.py`)
`is_terminal` runs after `generate_request` has overwritten `request_array`, but `get_reward_failure` read `state.request_array[1]`. With `reward_type=bitrate` (or `maximise_throughput`), blocked steps only terminated when consecutive bitrates happened to match, so episodes configured to end on first blocking ran on — inflating incremental-loading capacity measurements. `get_reward_failure` now uses `action_info.requested_datarate`, captured in `process_action` before any mutation, so both call sites compute bitwise-identical values. This also removes a `differentiable_index` call on the tuple returned by `read_rsa_request`, which would have crashed under `--differentiable`.

### 3. `reward_type=mod_format` unusable in every configuration (`rsa.py`)
The branch asserted `RSAGNModelEnvParams` but reads `modulation_format_index_array`, which only exists on `RMSAGNModelEnvState`: rmsa_gn_model failed the assert at trace time; rsa_gn_model passed it then raised AttributeError. The assert now requires `RMSAGNModelEnvParams` (both derive from `GNModelEnvParams`; neither subclasses the other).

### 4. Blocking metrics included the warmup transient (`xlron/train/train_utils.py`)
With `continuous_operation`, the cumulative counters (`accepted_services`, `accepted_bitrate`, `total_bitrate`) and LogWrapper's `lengths`/`cum_returns` were never reset after `ENV_WARMUP_STEPS`, so every logged blocking probability — wandb curves, the JSONL summary, and best-model selection — was a lifetime average including the near-zero-blocking network-fill period (e.g. warmup=3000 + 10000 steps at 5% steady-state blocking reported ~3.8%). New `reset_warmup_metric_counters()` zeroes the metrics-only counters after warmup in `experiment_data_setup` (guarded by `ENV_WARMUP_STEPS`); `total_requests`, which drives episode truncation, is preserved, and `jnp.zeros_like` keeps shapes/dtypes stable for the jitted learner. The eval-during-training path already subtracted warmup counters explicitly and is unchanged. Note: the multidevice variants (`ppo_multidevice.py`, `ppo_stoix.py`) have their own warmup invocations and are out of scope here.

### 5. LogWrapper logged the wrong path's SNR and next-request fields (`xlron/environments/wrappers.py`)
Two layers of wrongness in `LogWrapper.step`'s `log_actions` block:
- `log_state` is rebound to the new `LogEnvState` before the info block, so *all* request-derived fields (`source`, `dest`, `data_rate`, `path_index`, `slot_index`, `arrival_time`, `departure_time`) described the NEXT request, not the one the action was taken for. The pre-step state is now captured (`prev_env_state`) and used for those fields.
- `path_snr` indexed `path_link_array` with the k-relative path index (0..k-1), missing the node-pair offset `i` and the `pack_path_bits` unpack, so it always reported the SNR of one of the first node pair's paths. It now uses the global row `(i + path_index)`, mirroring `get_paths_obs_gn_model`. SNR values are still read from the post-step `link_snr_array` (SNR after allocation is the intended reading).

### 6. `prioritization/*` metrics computed but never logged (`train_utils.py`)
`_update_step` puts `prioritization/beta|priority_mean|priority_std` in `loss_info` every update, but they were absent from the wandb registry and log dict — exactly the CLAUDE.md "forgetting step 3" failure mode. Added a `prioritization_metrics` list, registered in `setup_wandb`, and merged into the loss log dict in `log_metrics`.

### 7. (Optional) `truncate_holding_time` PRNG aliasing (`xlron/environments/env_funcs.py`)
The truncation branch re-split the *parent* key for its 5 candidate keys; `jax.random.split` is prefix-stable (`split(key,5)[:2] == split(key,2)`), so candidate 0 reused `key_arrival` — ~3.4e-4 of requests had holding times perfectly correlated with inter-arrival times. Now splits the child `key_holding`. Selection semantics (last-valid-candidate, zero fallback) deliberately unchanged.

## Tests added
- `rsa_test.py::RewardTypeBitrateTest` — success reward = +bitrate/max, failure = -bitrate/max (fails pre-fix: success was 0)
- `rsa_test.py::EndFirstBlockingBitrateTest` — every blocked step terminal with mixed bitrates under `end_first_blocking` + `reward_type=bitrate`
- `gn_model_test.py::ModFormatRewardTest` — rmsa_gn_model + `reward_type=mod_format` traces and steps (failed at trace time pre-fix)
- `gn_model_test.py::LogWrapperActionLoggingTest` — `path_snr` matches `get_snr_for_path` on the actually-selected global path row; arrival/departure times match the pre-step request (verified to fail against the pre-fix wrapper)
- `train_utils_test.py` (new file) — `reset_warmup_metric_counters` zeroes metric counters, preserves `total_requests` and pytree shapes/dtypes; every `loss_info` key in `ppo.py` is in a registered wandb metric list
- `env_funcs_test.py::test_truncated_holding_time_independent_of_arrival_time` — 50k-key sweep, zero aliased draws (pre-fix code yields 14)

## Behavior changes
- `reward_type=bitrate` now gives positive success rewards (was 0); `snr`/`mod_format` rewards regain the bitrate base term — reward scales change for these training configs (documented launch-power quickstart flow is affected/repaired).
- `end_first_blocking` + non-service reward types now terminates on the first block as documented; capacity measurements under these configs will drop to their correct values.
- Logged blocking probabilities with `ENV_WARMUP_STEPS>0` + `continuous_operation` now exclude the warmup transient (reported values rise to true steady-state); best-model selection is no longer initialised against a warmup-diluted metric.
- `log_actions` CSVs now describe the acting request (fields previously shifted by one request) and the correct path's SNR.
- `prioritization/*` metrics appear in wandb.
- RNG stream changes slightly for `truncate_holding_time` runs (candidate keys now independent).

---
*Part of a 13-PR batch from an automated multi-agent codebase review (each finding independently adversarially verified, each diff reviewed, full test suite green per branch). Sibling PRs may touch adjacent lines; expect occasional rebases as they merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)