### PR TITLE
Log spectrum-fragmentation metric alongside utilisation

### DIFF
--- a/docs/understanding_xlron.md
+++ b/docs/understanding_xlron.md
@@ -143,6 +143,8 @@ Weights and Biases is a tool for experiment tracking, model management, and hype
 
 Hyperparameters (e.g. learning rate, batch size, rollout length, discount factor (gamma), generalized advantage estimation (GAE) lambda factor, number of MLP layers, number of hidden units, number of parallel environments, etc.) are extremely important for the success of any deep learning model and especially for reinforcement learning, which introduces additional parameters.
 
+Each logging increment reports per-step and episode-end aggregates (mean, std, IQR) of the core metrics: returns, episode lengths, accepted services/bitrate, service and bitrate blocking probabilities, spectrum utilisation and spectrum fragmentation. Utilisation is the fraction of occupied slots in the link-slot array. Fragmentation is the mean external fragmentation across links, `1 - largest_free_block / total_free_slots` per link — 0 when each link's free spectrum is contiguous (or the link is completely full or empty), approaching 1 as free slots splinter into many small blocks. Both are computed from the post-step network state every step and flow to wandb and `--EPISODE_DATA_OUTPUT_FILE` alongside the other metrics.
+
 XLRON features support for wandb experiment tracking and hyperparameter sweeps. The following commandline flags, when running the 'train.py' script, will enable wandb integration:
 
 ```bash

--- a/xlron/environments/dataclasses.py
+++ b/xlron/environments/dataclasses.py
@@ -176,6 +176,7 @@ class LogEnvState:
         accepted_bitrate (chex.Scalar): Accepted bitrate
         total_bitrate (chex.Scalar): Total bitrate requested
         utilisation (chex.Scalar): Network utilisation
+        fragmentation (chex.Scalar): Mean external spectrum fragmentation across links
         terminal (chex.Scalar): Terminal flag (true termination condition met)
         truncated (chex.Scalar): Truncated flag (max steps reached)
     """
@@ -188,6 +189,7 @@ class LogEnvState:
     accepted_bitrate: Array
     total_bitrate: Array
     utilisation: Array
+    fragmentation: Array
     terminal: Array
     truncated: Array
 

--- a/xlron/environments/env_funcs.py
+++ b/xlron/environments/env_funcs.py
@@ -2671,6 +2671,43 @@ def find_block_sizes(
     return block_sizes
 
 
+@jax.jit
+def calculate_fragmentation(link_slot_array: Array) -> Array:
+    """Calculate mean external spectrum fragmentation across links.
+
+    External fragmentation per link = 1 - largest_free_block / total_free_slots.
+    It is 0 when each link's free capacity is contiguous (or the link is completely
+    full/empty) and approaches 1 as free slots are scattered into many small blocks.
+
+    Occupancy follows the same convention as the utilisation metric: any non-zero
+    value counts as occupied (in-service slots are stored as negative values).
+    Uses an O(links x slots) cumulative-max scan (no NxN block-size matrices as in
+    find_block_sizes), so it is cheap enough to compute on the hot path every step.
+
+    Args:
+        link_slot_array: Link-slot occupancy array of shape (num_links, num_slots)
+
+    Returns:
+        Scalar mean external fragmentation across links
+    """
+    occupied = link_slot_array != 0
+    num_slots = link_slot_array.shape[1]
+    slot_indices = jnp.arange(num_slots, dtype=dtype_config.INDEX_DTYPE)[None, :]
+    # Index of the most recent occupied slot at or before each position (-1 if none),
+    # so (slot_index - last_occupied) is the length of the free run ending at each slot
+    last_occupied = jax.lax.cummax(jnp.where(occupied, slot_indices, -1), axis=1)
+    free_run_lengths = jnp.where(occupied, 0, slot_indices - last_occupied)
+    largest_free_block = jnp.max(free_run_lengths, axis=1)
+    total_free_slots = jnp.sum(~occupied, axis=1)
+    # Fully-occupied links have no free capacity to fragment, so report 0
+    fragmentation_per_link = jnp.where(
+        total_free_slots > 0,
+        1.0 - largest_free_block / jnp.maximum(total_free_slots, 1),
+        0.0,
+    )
+    return jnp.mean(fragmentation_per_link).astype(dtype_config.LARGE_FLOAT_DTYPE)
+
+
 @partial(jax.jit, static_argnums=(1,))
 def calculate_path_stats(state, params, request):
     nodes_sd, requested_datarate = read_rsa_request(request)

--- a/xlron/environments/env_funcs_test.py
+++ b/xlron/environments/env_funcs_test.py
@@ -1255,6 +1255,47 @@ class FindBlockSizesTest(chex.TestCase):
         chex.assert_trees_all_close(actual, expected)
 
 
+class CalculateFragmentationTest(chex.TestCase):
+    def setUp(self):
+        super().setUp()
+
+    @chex.all_variants()
+    @parameterized.named_parameters(
+        ("case_empty", jnp.zeros((2, 8)), 0.0),
+        ("case_full", jnp.ones((2, 8)), 0.0),
+        ("case_contiguous_free", jnp.array([[1, 1, 1, 0, 0, 0, 0, 0]]), 0.0),
+        ("case_checkerboard", jnp.array([[0, 1, 0, 1, 0, 1, 0, 1]]), 0.75),
+        # Negative values (in-service slots) count as occupied: free runs of 2 and 4
+        ("case_negative_occupied", jnp.array([[-1, 0, 0, -1, 0, 0, 0, 0]]), 1 - 4 / 6),
+        # Mean across links: contiguous link (0) and checkerboard link (0.75)
+        (
+            "case_mean_over_links",
+            jnp.array([[0, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 1, 0, 1, 0, 1]]),
+            0.375,
+        ),
+    )
+    def test_calculate_fragmentation(self, link_slot_array, expected):
+        actual = self.variant(calculate_fragmentation)(link_slot_array)
+        chex.assert_trees_all_close(actual, jnp.array(expected, dtype=actual.dtype))
+
+
+class FragmentationLoggingTest(chex.TestCase):
+    """LogWrapper must surface the fragmentation metric stashed by step_env."""
+
+    def test_fragmentation_in_info_and_log_state(self):
+        env, params = make(settings_rwa_4node())
+        key = jax.random.PRNGKey(0)
+        obs, log_state = env.reset(key, params)
+        chex.assert_trees_all_close(
+            log_state.fragmentation, jnp.array(0, dtype=log_state.fragmentation.dtype)
+        )
+        step = jax.jit(env.step, static_argnums=(3,))
+        _, log_state, _, _, _, info = step(key, log_state, jnp.array(0), params)
+        expected = calculate_fragmentation(log_state.env_state.link_slot_array)
+        chex.assert_trees_all_close(info["fragmentation"], expected)
+        chex.assert_trees_all_close(log_state.fragmentation, expected)
+
+
 class TopologyNodeIdNormalisationTest(chex.TestCase):
     """make_graph must relabel mixed-base topology JSONs to 0..N-1 in sorted-id order.
 

--- a/xlron/environments/rsa/rsa.py
+++ b/xlron/environments/rsa/rsa.py
@@ -20,6 +20,7 @@ from xlron.environments.dataclasses import (
 )
 from xlron.environments.diff_utils import *
 from xlron.environments.env_funcs import (
+    calculate_fragmentation,
     calculate_path_stats,
     check_action_rmsa_gn_model,
     check_action_rsa,
@@ -315,6 +316,7 @@ class RSAEnv(environment.Environment):
         info["_accepted_bitrate"] = state.accepted_bitrate
         info["_total_bitrate"] = state.total_bitrate
         info["_utilisation"] = jnp.count_nonzero(state.link_slot_array) / state.link_slot_array.size
+        info["_fragmentation"] = calculate_fragmentation(state.link_slot_array)
         if params.render:
             # Expose exact action_info/check used internally by step_env for render/debug paths.
             info["_render_action"] = action_info.action

--- a/xlron/environments/wrappers.py
+++ b/xlron/environments/wrappers.py
@@ -51,6 +51,7 @@ class LogWrapper(GymnaxWrapper):
             accepted_bitrate=jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE),
             total_bitrate=jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE),
             utilisation=jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE),
+            fragmentation=jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE),
             terminal=jnp.array(False),
             truncated=jnp.array(False),
         )
@@ -73,6 +74,10 @@ class LogWrapper(GymnaxWrapper):
         accepted_bitrate = info.pop("_accepted_bitrate")
         total_bitrate = info.pop("_total_bitrate")
         utilisation = info.pop("_utilisation")
+        # Default for envs (e.g. VONE) that don't stash fragmentation in step_env
+        fragmentation = info.pop(
+            "_fragmentation", jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE)
+        )
         # Compute final episode length (for reporting) before resetting
         episode_length = log_state.lengths + 1
         cum_returns = log_state.cum_returns + reward
@@ -86,6 +91,7 @@ class LogWrapper(GymnaxWrapper):
             accepted_bitrate=accepted_bitrate,
             total_bitrate=total_bitrate,
             utilisation=utilisation,
+            fragmentation=fragmentation,
             terminal=terminal,
             truncated=truncated,
         )
@@ -98,6 +104,7 @@ class LogWrapper(GymnaxWrapper):
         info["accepted_bitrate"] = log_state.accepted_bitrate
         info["total_bitrate"] = log_state.total_bitrate
         info["utilisation"] = log_state.utilisation
+        info["fragmentation"] = log_state.fragmentation
         info["terminal"] = terminal
         info["truncated"] = truncated
         # First check if we're dealing with RSAGNModelEnvParams

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -58,6 +58,7 @@ metrics = [
     "accepted_bitrate",
     "total_bitrate",
     "utilisation",
+    "fragmentation",
     "service_blocking_probability",
     "bitrate_blocking_probability",
     "throughput",  # Only for RSA GN Model


### PR DESCRIPTION
## What

Adds a per-step **spectrum-fragmentation metric** to the standard logging pipeline, next to utilisation. The project's own capacity-bounds work (docs/capacity_bounds.md) concludes fragmentation is the larger source of lost capacity than routing inefficiency, and a fragmentation-aware heuristic (`kmf_ff`) already exists — but no fragmentation time series was ever exposed, forcing researchers to post-process raw states (impractical in the fully-jitted pipeline).

## How

- **`xlron/environments/env_funcs.py`** — new jitted `calculate_fragmentation(link_slot_array)`: mean external fragmentation across links, `1 - largest_free_block / total_free_slots` per link. Implemented with an O(links × slots) `lax.cummax` free-run scan (deliberately *not* reusing `find_block_sizes`, which builds O(S²) matrices per link and defaults to differentiable mode), so it is cheap enough for the hot path — comparable to the existing `count_nonzero` utilisation. Occupancy convention matches utilisation: any non-zero slot (including negative in-service markers) is occupied. Fully-free and fully-occupied links report 0. Returns `LARGE_FLOAT_DTYPE` so the `lax.scan` carry is stable under `--mixed_precision`.
- **`xlron/environments/rsa/rsa.py`** — `step_env` stashes `info["_fragmentation"]` next to `info["_utilisation"]` (pre-auto-reset, so the done step carries correct final-episode values).
- **`xlron/environments/dataclasses.py` / `xlron/environments/wrappers.py`** — `fragmentation` field added to `LogEnvState`, initialised in `LogWrapper.reset` and popped in `LogWrapper.step` with a typed zero default (VONE's `step_env` stashes no metrics keys, so the default avoids adding to that path's breakage); surfaced as `info["fragmentation"]`.
- **`xlron/train/train_utils.py`** — `"fragmentation"` registered in the `metrics` list, so it is defined in wandb (`setup_wandb`), aggregated (mean/std/IQR, per-step and episode-end) in `process_metrics`, and written to `EPISODE_DATA_OUTPUT_FILE`.
- **`docs/understanding_xlron.md`** — documented the logged core metrics including the fragmentation definition.

No new flag: the metric is always-on since its cost matches the existing utilisation computation.

## Tests

- `CalculateFragmentationTest` (env_funcs_test.py, all chex variants): empty/full links → 0, contiguous free → 0, checkerboard → 0.75, negative in-service markers count as occupied, per-link averaging.
- `FragmentationLoggingTest`: full `make()` → reset → jitted `LogWrapper.step` on the rwa_4node env, asserting `info["fragmentation"]` and `LogEnvState.fragmentation` match `calculate_fragmentation(state.link_slot_array)`.
- Targeted suites green: `env_funcs_test.py`, `make_env_test.py`, `dtype_config_test.py` (254 passed, 53 skipped).
- Smoke runs: heuristic eval (`ksp_ff`) and RL training with `--mixed_precision` both report the new metric end-to-end (fragmentation 0.05 at utilisation 0.90 on the tiny 4-node config, as expected).

## Behavior changes

- New `fragmentation` metric appears in wandb dashboards, printed increment summaries, and episode-data CSVs for all RSA-family environments (RSA/RMSA/RWA/DeepRMSA/RWA-LR/GN-model). Existing metrics are unchanged.
- `LogEnvState` has a new `fragmentation` field; external code constructing it directly must supply the field (in-repo, only `wrappers.py` constructs it).
- Per-step cost: one additional O(links × slots) cumulative-max over `link_slot_array`; no measurable change in the smoke-run throughput.

---
*Part of a 13-PR batch from an automated multi-agent codebase review (each finding independently adversarially verified, each diff reviewed, full test suite green per branch). Sibling PRs may touch adjacent lines; expect occasional rebases as they merge.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)