### PR TITLE
Repair launch_power_type=rl RL training path (stacked on models + ppo PRs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ ignore = ["E731"]
 [tool.pytest.ini_options]
 testpaths = ["."]
 norecursedirs = [".claude", "experimental", ".venv", "build", "site", "wandb"]
+markers = [
+    "slow: end-to-end smoke tests that compile a full training run (deselect with -m \"not slow\")",
+]
 
 [tool.isort]
 multi_line_output = 3

--- a/xlron/environments/gn_model/rsa_gn_model.py
+++ b/xlron/environments/gn_model/rsa_gn_model.py
@@ -11,6 +11,7 @@ from gymnax.environments import spaces
 
 from xlron.environments.dataclasses import *
 from xlron.environments.env_funcs import (
+    get_paths_obs_gn_model,
     init_active_lightpaths_array,
     init_active_lightpaths_array_departure,
     init_channel_centre_bw_array,
@@ -108,8 +109,10 @@ class RSAGNModelEnv(RSAEnv):
         ),
     )
     def get_obs(self, state: RSAGNModelEnvState, params: RSAGNModelEnvParams) -> Array:
-        # Return minimal observation since we're monitoring active lightpaths for throughput tracking
-        return jnp.array(0)
+        # Must match observation_space (4 + 7*k_paths features); a 0-d placeholder here
+        # crashes any flat-obs model (e.g. LaunchPowerActorCriticMLP) at trace time.
+        # Same fix as on the gn-physics branch (kept identical to merge cleanly).
+        return get_paths_obs_gn_model(state, params)
 
     @staticmethod
     def num_actions(params: RSAEnvParams) -> int:

--- a/xlron/heuristics/eval_heuristic.py
+++ b/xlron/heuristics/eval_heuristic.py
@@ -21,7 +21,9 @@ def get_eval_fn(
         def _env_step(runner_state, unused):
             eval_state, env_state, last_obs, step_key, rng_epoch = runner_state
 
-            action_key, next_step_key = jax.random.split(step_key)
+            # Dedicated keys for action selection and env stepping; the parent step_key is
+            # only ever split, never consumed directly.
+            action_key, env_key, next_step_key = jax.random.split(step_key, 3)
 
             # SELECT ACTION
             select_action_state = (action_key, env_state, last_obs)
@@ -31,7 +33,7 @@ def get_eval_fn(
 
             # STEP ENV
             obsv, env_state, reward, terminal, truncated, info = env.step(
-                step_key, env_state, action, env_params
+                env_key, env_state, action, env_params
             )
 
             obsv = (

--- a/xlron/models/gnn.py
+++ b/xlron/models/gnn.py
@@ -1004,10 +1004,13 @@ class ActorGNN(eqx.Module):
             if self.discrete:
                 power_action_dist = distrax.Categorical(logits=power_logits)
             else:
-                alpha = self.min_concentration + jax.nn.softplus(power_logits) * (
+                # The power head outputs 2 components per path: one parameterises alpha, the
+                # other beta (mirrors LaunchPowerActorCriticMLP). Splitting them gives a Beta
+                # with batch shape (k_paths,) whose mean the agent can actually learn.
+                alpha = self.min_concentration + jax.nn.softplus(power_logits[..., 0]) * (
                     self.max_concentration - self.min_concentration
                 )
-                beta = self.min_concentration + jax.nn.softplus(power_logits) * (
+                beta = self.min_concentration + jax.nn.softplus(power_logits[..., 1]) * (
                     self.max_concentration - self.min_concentration
                 )
                 power_action_dist = distrax.Beta(alpha, beta)
@@ -1191,7 +1194,7 @@ class ActorCriticGNN(eqx.Module):
     def sample_action_path(self, seed, dist, log_prob=False, deterministic=False):
         """Sample an action from the distribution."""
         action = (
-            jnp.argmax(dist.probs()).astype(dtype_config.INDEX_DTYPE)
+            dist.mode().astype(dtype_config.INDEX_DTYPE)
             if deterministic
             else dist.sample(seed=seed)
         )
@@ -1223,11 +1226,14 @@ class ActorCriticGNN(eqx.Module):
 
     def sample_action_path_power(self, seed, dist, log_prob=False, deterministic=False):
         """Sample an action from the distributions."""
+        # Independent keys per draw: reusing the same key couples the path and power samples,
+        # so the joint would not be the product of marginals that the summed log_prob assumes.
+        path_seed, power_seed = jax.random.split(seed)
         path_action = self.sample_action_path(
-            seed, dist[0], log_prob=log_prob, deterministic=deterministic
+            path_seed, dist[0], log_prob=log_prob, deterministic=deterministic
         )
         power_action = self.sample_action_power(
-            seed, dist[1], log_prob=log_prob, deterministic=deterministic
+            power_seed, dist[1], log_prob=log_prob, deterministic=deterministic
         )
         if log_prob:
             return path_action[0], power_action[0], path_action[1] + power_action[1]

--- a/xlron/models/mlp.py
+++ b/xlron/models/mlp.py
@@ -133,6 +133,7 @@ class MLP(eqx.Module):
         dropout_rate: float = 0.0,
         deterministic: bool = True,
         layer_norm: bool = False,
+        output_scale: float = np.sqrt(2),
         *,
         key: Array,
     ):
@@ -145,8 +146,11 @@ class MLP(eqx.Module):
         current_in = in_features
 
         for i, out_features in enumerate(features):
+            # Hidden layers use the standard sqrt(2) orthogonal gain; the output layer
+            # uses output_scale (e.g. 0.01 for a policy head, 1.0 for a value head).
+            scale = output_scale if i == len(features) - 1 else np.sqrt(2)
             linear = make_linear_with_orthogonal_init(
-                current_in, out_features, keys[i], scale=np.sqrt(2)
+                current_in, out_features, keys[i], scale=scale
             )
             layers_list.append(linear)
             if layer_norm and i < len(features) - 1:
@@ -173,8 +177,8 @@ class MLP(eqx.Module):
 class ActorCriticMLP(eqx.Module):
     """Actor-Critic MLP using Equinox."""
 
-    actor: eqx.Module
-    critic: eqx.Module
+    actor: MLP
+    critic: MLP
     activation_fn: Callable
     temperature: float
 
@@ -196,7 +200,7 @@ class ActorCriticMLP(eqx.Module):
         self.activation_fn = select_activation(activation)
         self.temperature = temperature
 
-        # Build actor layers
+        # Build actor layers (logits head init scale 0.01 for a near-uniform initial policy)
         actor_features = [num_units] * num_layers + [action_dim]
         self.actor = MLP(
             actor_features,
@@ -205,6 +209,7 @@ class ActorCriticMLP(eqx.Module):
             layer_norm=layer_norm,
             dropout_rate=dropout_rate,
             deterministic=deterministic,
+            output_scale=0.01,
             key=actor_key,
         )
         critic_features = [num_units] * num_layers + [1]
@@ -215,7 +220,8 @@ class ActorCriticMLP(eqx.Module):
             layer_norm=layer_norm,
             dropout_rate=dropout_rate,
             deterministic=deterministic,
-            key=actor_key,
+            output_scale=1.0,
+            key=critic_key,
         )
 
     def __call__(self, x: Array, key: Optional[Array] = None) -> Tuple[distrax.Categorical, Array]:
@@ -239,7 +245,7 @@ class ActorCriticMLP(eqx.Module):
         deterministic: bool = False,
     ) -> Union[Array, Tuple[Array, Array]]:
         """Sample an action from the distribution"""
-        action = jnp.argmax(dist.probs()) if deterministic else dist.sample(seed=seed)
+        action = dist.mode() if deterministic else dist.sample(seed=seed)
         if log_prob:
             return action, dist.log_prob(action)
         return action
@@ -252,9 +258,17 @@ class LaunchPowerActorCriticMLP(eqx.Module):
     Makes K forward passes, one for each path, and outputs a distribution over power levels for each path.
     """
 
+    # Actor trunk and discrete head
+    actor_layers: tuple
+    actor_output: Optional[eqx.nn.Linear]
+
     # For continuous action space (Beta distribution)
     alpha_out: Optional[eqx.nn.Linear]
     beta_out: Optional[eqx.nn.Linear]
+
+    # Critic trunk and value head
+    critic_layers: tuple
+    critic_output: eqx.nn.Linear
 
     # Static configuration
     activation: str = eqx.field(static=True)
@@ -339,6 +353,24 @@ class LaunchPowerActorCriticMLP(eqx.Module):
             self.alpha_out = make_linear_with_orthogonal_init(num_units, 1, out_key2, scale=0.01)
             self.beta_out = make_linear_with_orthogonal_init(num_units, 1, out_key3, scale=0.01)
 
+        # Build critic layers (take the full observation: base + all K paths' features)
+        critic_trunk_key, critic_out_key = jax.random.split(critic_key)
+        critic_keys = jax.random.split(critic_trunk_key, num_layers)
+        critic_layers_list = []
+        current_in = num_base_features + k_paths * num_path_features
+        for i in range(num_layers):
+            linear = make_linear_with_orthogonal_init(
+                current_in, num_units, critic_keys[i], scale=np.sqrt(2)
+            )
+            critic_layers_list.append(linear)
+            if layer_norm:
+                critic_layers_list.append(eqx.nn.LayerNorm(num_units))
+            current_in = num_units
+        self.critic_layers = tuple(critic_layers_list)
+        self.critic_output = make_linear_with_orthogonal_init(
+            num_units, 1, critic_out_key, scale=1.0
+        )
+
     @property
     def num_power_levels(self):
         """Calculate number of power levels dynamically"""
@@ -369,6 +401,10 @@ class LaunchPowerActorCriticMLP(eqx.Module):
         return x
 
     def __call__(self, x: Array) -> Tuple[Tuple[None, distrax.Distribution], Array]:
+        # Cast the (possibly low-precision under mixed precision) observation up to the NN compute
+        # dtype so weights, activations and the optimizer stay at full precision for stability.
+        x = x.astype(dtype_config.COMPUTE_DTYPE)
+
         # Process each path
         def process_path(i):
             base = x[: self.num_base_features]
@@ -395,8 +431,13 @@ class LaunchPowerActorCriticMLP(eqx.Module):
         )
 
         # Critic forward pass
-        critic_hidden = self._forward_layers(x, self.critic_layers)  # ty: ignore[unresolved-attribute]
-        value = jnp.squeeze(self.critic_output(critic_hidden), axis=-1)  # ty: ignore[unresolved-attribute]
+        critic_hidden = self._forward_layers(x, self.critic_layers)
+        value = jnp.squeeze(self.critic_output(critic_hidden), axis=-1)
+
+        # Cast outputs back to PARAMS_DTYPE (float32) so bf16 stays inside the model (see
+        # ActorCriticMLP for rationale).
+        dist_params = dist_params.astype(dtype_config.PARAMS_DTYPE)
+        value = value.astype(dtype_config.PARAMS_DTYPE)
 
         # Create distribution
         if self.discrete:
@@ -415,7 +456,8 @@ class LaunchPowerActorCriticMLP(eqx.Module):
                 raw_action = dist.mode()
             else:
                 raw_action = dist.sample(seed=seed)
-            processed_action = self.power_levels[raw_action].reshape((self.k_paths, 1))
+            # (k_paths,) to match the carried launch_power_array shape
+            processed_action = self.power_levels[raw_action].reshape((self.k_paths,))
         else:
             if deterministic:
                 mean = dist.alpha / (dist.alpha + dist.beta)
@@ -433,7 +475,7 @@ class LaunchPowerActorCriticMLP(eqx.Module):
     def get_action_probs(self, dist):
         """Get probabilities for discrete case or pdf for continuous case"""
         if self.discrete:
-            return dist.probs()
+            return dist.probs
         else:
             x = jnp.linspace(0, 1, 100)
             return dist.prob(x)

--- a/xlron/models/models_test.py
+++ b/xlron/models/models_test.py
@@ -292,11 +292,12 @@ class InitNetworkDispatchTest(chex.TestCase):
                 min_power=-5.0,
                 max_power=0.5,
                 step_power=0.1,
-                k_paths=4,
+                k=4,  # config key is "k" (experiment_data_setup syncs it to env k_paths)
             )
         )
         network = init_network(config, jax.random.PRNGKey(0))
         self.assertIsInstance(network, LaunchPowerActorCriticMLP)
+        self.assertEqual(network.k_paths, 4)  # ty: ignore[unresolved-attribute]
 
 
 class GNNPathPowerSamplingTest(chex.TestCase):

--- a/xlron/models/models_test.py
+++ b/xlron/models/models_test.py
@@ -1,0 +1,455 @@
+"""Tests for xlron.models: init scales, launch-power heads, and action sampling.
+
+Covers regressions fixed in the models bundle:
+- actor/critic output-head orthogonal init scales (0.01 / 1.0, matching the original
+  Flax models) and independent actor/critic init keys
+- LaunchPowerActorCriticMLP construction (undeclared eqx fields) and critic forward pass
+- degenerate GNN continuous launch-power Beta distribution (alpha == beta)
+- distrax .probs property called as a method in deterministic sampling
+- shared PRNG key for joint path/power sampling
+- init_network dispatch for launch_power_type="rl" with the MLP model
+"""
+
+import chex
+import distrax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from absl.testing import absltest
+from box import Box
+
+from xlron import dtype_config
+from xlron.environments.gn_model.isrs_gn_model import from_dbm
+from xlron.environments.make_env import make
+from xlron.models.gnn import ActorCriticGNN
+from xlron.models.mlp import ActorCriticMLP, LaunchPowerActorCriticMLP
+from xlron.models.transformer import ActorCriticTransformer
+from xlron.train.train_utils import TrainState, init_network, select_action
+
+# Module-level caches for expensive make() calls (mirrors gn_model_test.py)
+_env_cache = {}
+
+
+def _cached_env(cache_key, settings, seed=0):
+    key = jax.random.PRNGKey(seed)
+    if cache_key not in _env_cache:
+        _env_cache[cache_key] = make(settings)  # LogWrapper-wrapped
+    env, params = _env_cache[cache_key]
+    obs, state = env.reset(key, params)
+    return key, env, obs, state, params
+
+
+def rsa_gn_model_rl_setup():
+    return _cached_env(
+        "rsa_gn_model_rl",
+        dict(
+            k=4,
+            topology_name="nsfnet_deeprmsa_undirected",
+            link_resources=8,
+            max_requests=10,
+            values_bw=[100],
+            incremental_loading=True,
+            env_type="rsa_gn_model",
+            interband_gap=0,
+            slot_size=25,
+            mod_format_correction=False,
+            launch_power_type="rl",
+            launch_power=0.0,
+        ),
+    )
+
+
+def rmsa_gn_model_rl_setup():
+    return _cached_env(
+        "rmsa_gn_model_rl",
+        dict(
+            k=4,
+            topology_name="nsfnet_deeprmsa_directed",
+            link_resources=10,
+            max_requests=100,
+            values_bw=[100],
+            incremental_loading=True,
+            env_type="rmsa_gn_model",
+            slot_size=12.5,
+            guardband=0,
+            mod_format_correction=False,
+            max_power_per_fibre=10.0,
+            coherent=False,
+            include_no_op=False,
+            launch_power_type="rl",
+        ),
+        seed=3,
+    )
+
+
+def make_small_gnn(state, params, discrete, key=1):
+    """ActorCriticGNN sized to the cached rsa_gn_model env's graph tuple."""
+    edge_feat = int(np.prod(state.env_state.graph.edges.shape[1:]))
+    node_feat = int(state.env_state.graph.nodes.shape[-1])
+    return ActorCriticGNN(
+        input_edge_features=edge_feat,
+        input_node_features=node_feat,
+        input_global_features=1,
+        num_layers=1,
+        num_units=8,
+        message_passing_steps=1,
+        mlp_layers=1,
+        mlp_latent=8,
+        edge_embedding_size=8,
+        edge_mlp_layers=1,
+        edge_mlp_latent=8,
+        edge_output_size_actor=8,
+        edge_output_size_critic=0,
+        global_embedding_size=4,
+        global_mlp_layers=0,
+        global_mlp_latent=0,
+        global_output_size_actor=0,
+        global_output_size_critic=1,
+        node_embedding_size=4,
+        node_mlp_layers=1,
+        node_mlp_latent=8,
+        node_output_size_actor=0,
+        node_output_size_critic=0,
+        attn_mlp_layers=0,
+        attn_mlp_latent=0,
+        use_attention=False,
+        normalise_by_link_length=False,
+        gnn_layer_norm=True,
+        mlp_layer_norm=False,
+        vmap=False,
+        discrete=discrete,
+        min_power_dbm=-5.0,
+        max_power_dbm=0.5,
+        step_power_dbm=0.1,
+        key=jax.random.PRNGKey(key),
+    )
+
+
+def _gn_select_action_config(**overrides):
+    config = Box(
+        dict(
+            env_type="rsa_gn_model",
+            launch_power_type="rl",
+            USE_GNN=True,
+            USE_TRANSFORMER=False,
+            GNN_OUTPUT_RSA=True,
+            GNN_OUTPUT_LP=True,
+            global_output_size_actor=0,
+            deterministic=False,
+        )
+    )
+    config.update(overrides)
+    return config
+
+
+class MLPInitScaleTest(chex.TestCase):
+    """Orthogonal init: hidden layers sqrt(2), actor head 0.01, critic head 1.0."""
+
+    def setUp(self):
+        super().setUp()
+        self.model = ActorCriticMLP(10, 7, num_layers=2, num_units=16, key=jax.random.PRNGKey(0))
+
+    def test_head_and_hidden_init_scales(self):
+        # Orthogonal init scaled by `scale` has all singular values == scale
+        actor_head_sv = jnp.linalg.svd(self.model.actor.layers[-1].weight, compute_uv=False)
+        critic_head_sv = jnp.linalg.svd(self.model.critic.layers[-1].weight, compute_uv=False)
+        hidden_sv = jnp.linalg.svd(self.model.actor.layers[0].weight, compute_uv=False)
+        chex.assert_trees_all_close(actor_head_sv, jnp.full_like(actor_head_sv, 0.01), atol=1e-4)
+        chex.assert_trees_all_close(critic_head_sv, jnp.full_like(critic_head_sv, 1.0), atol=1e-4)
+        chex.assert_trees_all_close(hidden_sv, jnp.full_like(hidden_sv, np.sqrt(2)), atol=1e-4)
+
+    def test_actor_critic_hidden_layers_differ(self):
+        # Actor and critic must not start with byte-identical hidden weights
+        self.assertFalse(
+            bool(
+                jnp.array_equal(
+                    self.model.actor.layers[0].weight, self.model.critic.layers[0].weight
+                )
+            )
+        )
+
+    def test_sample_action_deterministic_is_mode(self):
+        dist = distrax.Categorical(logits=jnp.array([0.1, 2.0, -1.0, 0.5]))
+        action = self.model.sample_action(jax.random.PRNGKey(0), dist, deterministic=True)
+        self.assertEqual(int(action), 1)
+
+
+class TransformerInitTest(chex.TestCase):
+    def _make(self, share_layers):
+        return ActorCriticTransformer(
+            input_size=12,
+            embedding_size=8,
+            intermediate_size=16,
+            num_slot_actions=4,
+            num_layers=1,
+            num_heads=2,
+            enable_dropout=False,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            share_layers=share_layers,
+            num_wire_features=2,
+            actor_mlp_width=8,
+            critic_mlp_width=8,
+            actor_mlp_depth=1,
+            critic_mlp_depth=1,
+            num_request_specific_cols=5,
+            key=jax.random.PRNGKey(0),
+        )
+
+    def test_encoders_differ_when_not_shared(self):
+        model = self._make(share_layers=False)
+        actor_enc, critic_enc = model.actor_critic
+        # Transformer blocks have identical shapes for actor/critic; with independent init
+        # keys they must not start byte-identical.
+        actor_leaves = jax.tree_util.tree_leaves(actor_enc.layers)
+        critic_leaves = jax.tree_util.tree_leaves(critic_enc.layers)
+        any_diff = any(not bool(jnp.array_equal(a, c)) for a, c in zip(actor_leaves, critic_leaves))
+        self.assertTrue(any_diff)
+
+    def test_shared_encoder_is_same_object(self):
+        model = self._make(share_layers=True)
+        self.assertIs(model.actor_critic[0], model.actor_critic[1])
+
+    def test_sample_action_deterministic_is_mode(self):
+        model = self._make(share_layers=True)
+        dist = distrax.Categorical(logits=jnp.array([0.1, -2.0, 3.0, 0.5]))
+        action = model.sample_action(jax.random.PRNGKey(0), dist, deterministic=True)
+        self.assertEqual(int(action), 2)
+
+
+class LaunchPowerMLPTest(chex.TestCase):
+    """Construction + forward + sampling for LaunchPowerActorCriticMLP."""
+
+    K_PATHS = 4
+    OBS_DIM = 4 + 4 * 7  # num_base_features + k_paths * num_path_features
+
+    def _make(self, discrete):
+        return LaunchPowerActorCriticMLP(
+            1,
+            self.OBS_DIM,
+            num_layers=2,
+            num_units=16,
+            discrete=discrete,
+            min_power_dbm=-5.0,
+            max_power_dbm=0.5,
+            step_power_dbm=0.1,
+            k_paths=self.K_PATHS,
+            key=jax.random.PRNGKey(0),
+        )
+
+    def test_discrete_forward_and_sampling(self):
+        model = self._make(discrete=True)
+        obs = jax.random.normal(jax.random.PRNGKey(1), (self.OBS_DIM,))
+        (path_dist, dist), value = model(obs)
+        self.assertIsNone(path_dist)
+        self.assertIsInstance(dist, distrax.Categorical)
+        chex.assert_shape(dist.logits, (self.K_PATHS, model.num_power_levels))
+        chex.assert_shape(value, ())
+        action, log_prob = model.sample_action(jax.random.PRNGKey(2), dist, log_prob=True)
+        chex.assert_shape(action, (self.K_PATHS,))
+        chex.assert_shape(log_prob, (self.K_PATHS,))
+        # Powers are linear-unit conversions of the discrete dBm levels
+        valid_powers = from_dbm(model.power_levels)
+        self.assertTrue(bool(jnp.all(jnp.isin(action, valid_powers))))
+        det_action = model.sample_action(jax.random.PRNGKey(2), dist, deterministic=True)
+        chex.assert_shape(det_action, (self.K_PATHS,))
+        chex.assert_shape(model.get_action_probs(dist), (self.K_PATHS, model.num_power_levels))
+
+    def test_continuous_forward_and_sampling(self):
+        model = self._make(discrete=False)
+        obs = jax.random.normal(jax.random.PRNGKey(1), (self.OBS_DIM,))
+        (_, dist), value = model(obs)
+        self.assertIsInstance(dist, distrax.Beta)
+        self.assertEqual(dist.batch_shape, (self.K_PATHS,))
+        # Separate alpha/beta heads: generically not equal, so the mean is learnable
+        self.assertFalse(bool(jnp.all(dist.alpha == dist.beta)))
+        action, log_prob = model.sample_action(jax.random.PRNGKey(2), dist, log_prob=True)
+        chex.assert_shape(action, (self.K_PATHS,))
+        chex.assert_shape(log_prob, (self.K_PATHS,))
+        min_power, max_power = from_dbm(-5.0), from_dbm(0.5)
+        self.assertTrue(bool(jnp.all((action >= min_power) & (action <= max_power))))
+        det_action = model.sample_action(jax.random.PRNGKey(2), dist, deterministic=True)
+        chex.assert_shape(det_action, (self.K_PATHS,))
+
+
+class InitNetworkDispatchTest(chex.TestCase):
+    def test_launch_power_rl_dispatches_to_launch_power_mlp(self):
+        config = Box(
+            dict(
+                env_type="rmsa_gn_model",
+                USE_TRANSFORMER=False,
+                USE_GNN=False,
+                launch_power_type="rl",
+                ACTION_DIM=1,
+                INPUT_DIM=32,
+                include_no_op=False,
+                ACTIVATION="tanh",
+                NUM_LAYERS=2,
+                NUM_UNITS=16,
+                mlp_layer_norm=False,
+                discrete_launch_power=True,
+                min_power=-5.0,
+                max_power=0.5,
+                step_power=0.1,
+                k_paths=4,
+            )
+        )
+        network = init_network(config, jax.random.PRNGKey(0))
+        self.assertIsInstance(network, LaunchPowerActorCriticMLP)
+
+
+class GNNPathPowerSamplingTest(chex.TestCase):
+    """Path/power joint sampling must draw from independent keys."""
+
+    def setUp(self):
+        super().setUp()
+        _, _, _, state, params = rsa_gn_model_rl_setup()
+        self.model = make_small_gnn(state, params, discrete=True)
+
+    def test_sample_action_path_deterministic_is_mode(self):
+        dist = distrax.Categorical(logits=jnp.array([0.1, 2.0, -1.0]))
+        action = self.model.sample_action_path(jax.random.PRNGKey(0), dist, deterministic=True)
+        self.assertEqual(int(action), 1)
+        self.assertEqual(action.dtype, dtype_config.INDEX_DTYPE)
+
+    def test_path_power_samples_decorrelated(self):
+        num_paths, num_levels = 30, self.model.num_power_levels
+        path_dist = distrax.Categorical(logits=jnp.zeros(num_paths))
+        power_dist = distrax.Categorical(logits=jnp.zeros(num_levels))
+
+        def draw(key):
+            path_action, power_action, _ = self.model.sample_action_path_power(
+                key, (path_dist, power_dist), log_prob=True
+            )
+            return path_action, power_action
+
+        keys = jax.random.split(jax.random.PRNGKey(42), 8000)
+        path_actions, power_actions = jax.vmap(draw)(keys)
+        first_power = from_dbm(self.model.power_levels)[0]
+        picked_path0 = path_actions == 0
+        picked_power0 = jnp.isclose(power_actions, first_power)
+        # With a shared key the power draw is (nearly) a deterministic function of the path
+        # draw: P(power==levels[0] | path==0) == 1.0. Independent keys give the marginal.
+        conditional = jnp.sum(picked_path0 & picked_power0) / jnp.maximum(jnp.sum(picked_path0), 1)
+        self.assertLess(float(conditional), 0.5)
+        self.assertGreater(float(conditional), 1.0 / num_levels / 3)
+
+
+class GNNLaunchPowerIntegrationTest(chex.TestCase):
+    """End-to-end select_action for the GN-model RL launch-power modes."""
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = rsa_gn_model_rl_setup()
+
+    def _train_state(self, model):
+        return TrainState.create(model=model, tx=optax.adam(1e-3))
+
+    def test_continuous_power_dist_is_per_path_beta(self):
+        model = make_small_gnn(self.state, self.params, discrete=False)
+        (path_dist, power_dist), value = model(self.state.env_state, self.params)
+        self.assertIsInstance(power_dist, distrax.Beta)
+        self.assertEqual(power_dist.batch_shape, (self.params.k_paths,))
+        self.assertFalse(bool(jnp.all(power_dist.alpha == power_dist.beta)))
+
+    def test_select_action_path_and_power(self):
+        model = make_small_gnn(self.state, self.params, discrete=False)
+        config = _gn_select_action_config()
+        for seed, deterministic in [(3, False), (4, True)]:
+            config.deterministic = deterministic
+            env_state, action, log_prob, value = select_action(
+                (jax.random.PRNGKey(seed), self.state, None),
+                self.env,
+                self.params,
+                self._train_state(model),
+                config,
+            )
+            chex.assert_shape(action, (2,))  # [path_action, power]
+            chex.assert_shape(log_prob, ())
+            # Carried launch power array keeps its (k_paths,) shape and LARGE_FLOAT dtype
+            chex.assert_shape(env_state.env_state.launch_power_array, (self.params.k_paths,))
+            self.assertEqual(
+                env_state.env_state.launch_power_array.dtype,
+                jnp.dtype(dtype_config.LARGE_FLOAT_DTYPE),
+            )
+
+    def test_select_action_power_only(self):
+        model = make_small_gnn(self.state, self.params, discrete=False)
+        config = _gn_select_action_config(GNN_OUTPUT_RSA=False, GNN_OUTPUT_LP=True)
+        env_state, action, log_prob, value = select_action(
+            (jax.random.PRNGKey(3), self.state, None),
+            self.env,
+            self.params,
+            self._train_state(model),
+            config,
+        )
+        chex.assert_shape(action, (2,))
+        chex.assert_shape(env_state.env_state.launch_power_array, (self.params.k_paths,))
+
+    def test_select_action_discrete_power(self):
+        model = make_small_gnn(self.state, self.params, discrete=True)
+        config = _gn_select_action_config(deterministic=True)
+        env_state, action, log_prob, value = select_action(
+            (jax.random.PRNGKey(3), self.state, None),
+            self.env,
+            self.params,
+            self._train_state(model),
+            config,
+        )
+        chex.assert_shape(action, (2,))
+        valid_powers = from_dbm(model.power_levels)
+        self.assertTrue(bool(jnp.any(jnp.isclose(action[1], valid_powers, rtol=1e-5))))
+
+
+class LaunchPowerMLPSelectActionTest(chex.TestCase):
+    """Power-only RL launch power with the (non-GNN) MLP model, path via heuristic."""
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = rmsa_gn_model_rl_setup()
+
+    def test_select_action_power_only_mlp(self):
+        model = LaunchPowerActorCriticMLP(
+            1,
+            int(self.obs.shape[-1]),
+            num_layers=2,
+            num_units=16,
+            discrete=True,
+            min_power_dbm=-5.0,
+            max_power_dbm=0.5,
+            step_power_dbm=0.1,
+            k_paths=self.params.k_paths,
+            key=jax.random.PRNGKey(0),
+        )
+        train_state = TrainState.create(model=model, tx=optax.adam(1e-3))
+        config = Box(
+            dict(
+                env_type="rmsa_gn_model",
+                launch_power_type="rl",
+                USE_GNN=False,
+                USE_TRANSFORMER=False,
+                GNN_OUTPUT_RSA=False,
+                GNN_OUTPUT_LP=False,
+                global_output_size_actor=0,
+                deterministic=False,
+            )
+        )
+        env_state, action, log_prob, value = select_action(
+            (jax.random.PRNGKey(3), self.state, (self.obs,)),
+            self.env,
+            self.params,
+            train_state,
+            config,
+        )
+        chex.assert_shape(action, (2,))
+        chex.assert_shape(log_prob, ())
+        chex.assert_shape(env_state.env_state.launch_power_array, (self.params.k_paths,))
+        self.assertEqual(
+            env_state.env_state.launch_power_array.dtype,
+            jnp.dtype(dtype_config.LARGE_FLOAT_DTYPE),
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/xlron/models/transformer.py
+++ b/xlron/models/transformer.py
@@ -457,6 +457,10 @@ class ActorCriticTransformer(eqx.Module):
         self.embedding_size = embedding_size
         self.critic_pooling = critic_pooling
         self.actor_pooling = actor_pooling
+        # Give the critic encoder an independent init key so that with share_layers=False it
+        # does not start as an exact copy of the actor. The actor keeps encoder_key so its
+        # init is unchanged for a fixed seed.
+        critic_enc_key = jax.random.fold_in(encoder_key, 1)
         actor = Encoder(
             input_size=input_size,
             intermediate_size=intermediate_size,
@@ -477,7 +481,7 @@ class ActorCriticTransformer(eqx.Module):
             num_wire_features=num_wire_features,
             dropout_rate=dropout_rate,
             attention_dropout_rate=attention_dropout_rate,
-            key=encoder_key,
+            key=critic_enc_key,
         )
         if self.share_layers:
             # When sharing layers, use the same encoder for both actor and critic
@@ -618,7 +622,7 @@ class ActorCriticTransformer(eqx.Module):
         deterministic: bool = False,
     ) -> Union[Array, Tuple[Array, Array]]:
         """Sample an action from the distribution"""
-        action = jnp.argmax(dist.probs()) if deterministic else dist.sample(seed=seed)
+        action = dist.mode() if deterministic else dist.sample(seed=seed)
         if log_prob:
             return action, dist.log_prob(action)
         return action

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -545,11 +545,13 @@ def _loss_fn(
         # Repeat the power action along the last axis K-paths time
         power_actions = jnp.tile(power_actions[..., None], (1, config.k_paths))
         power_log_prob = power_dist.log_prob(power_actions)
-        # Slice log prob to just take the path index
-        power_log_prob = jax.vmap(lambda x, i: jax.lax.dynamic_slice(x, (i,), (1,)))(
-            power_log_prob, path_indices
-        )
-        power_entropy = power_dist.entropy()
+        # Select the chosen path's log prob / entropy, keeping shape (B,) to match
+        # path_log_prob and the rollout-time stored log_prob (a (B,1)/(B,k) leftover here
+        # would silently broadcast the ratio to (B,B) or fail at trace time).
+        power_log_prob = jnp.take_along_axis(power_log_prob, path_indices[:, None], axis=1)[:, 0]
+        power_entropy = jnp.take_along_axis(power_dist.entropy(), path_indices[:, None], axis=1)[
+            :, 0
+        ]
 
         log_prob = path_log_prob + power_log_prob
         entropy = path_entropy + power_entropy

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -25,6 +25,7 @@ from xlron.train.train_utils import (
     TrainState,
     cast_model_for_compute,
     select_action,
+    steps_per_train_state_unit,
 )
 
 RunnerState = Tuple[TrainState, LogEnvState, Obsv, Array, Array]
@@ -73,7 +74,14 @@ def _sample_prioritized_batch(
                 sample_key, batch_size, shape=(batch_size,), p=priority_probs.reshape((batch_size,))
             )
 
-            importance_weights = jnp.power(jnp.take(priority_probs, sampled_indices), -beta)
+            # Standard PER importance weights (Schaul et al. 2016): w_i = (N * P(i))^-beta,
+            # normalized by max_i w_i so weights are <= 1 and match the scale of the uniform
+            # path above (which uses weights of exactly 1.0).
+            importance_weights = jnp.power(
+                batch_size * jnp.take(priority_probs, sampled_indices), -beta
+            )
+            importance_weights = importance_weights / jnp.maximum(jnp.max(importance_weights), 1e-8)
+            importance_weights = importance_weights.astype(dtype_config.LARGE_FLOAT_DTYPE)
 
             batch = jax.tree.map(
                 lambda x: jnp.take(x.reshape((-1, *x.shape[2:])), sampled_indices, axis=0).reshape(
@@ -88,8 +96,14 @@ def _sample_prioritized_batch(
                 sample_key, config.NUM_ENVS, shape=(config.NUM_ENVS,), p=priority_probs
             )
 
+            # Standard PER importance weights over trajectories: w_i = (N * P(i))^-beta,
+            # max-normalized (N = NUM_ENVS trajectories).
+            trajectory_weights = jnp.power(
+                config.NUM_ENVS * jnp.take(priority_probs, sampled_indices), -beta
+            )
+            trajectory_weights = trajectory_weights / jnp.maximum(jnp.max(trajectory_weights), 1e-8)
             importance_weights = jnp.tile(
-                jnp.power(jnp.take(priority_probs, sampled_indices), -beta),
+                trajectory_weights.astype(dtype_config.LARGE_FLOAT_DTYPE),
                 (config.ROLLOUT_LENGTH, 1),
             )
 
@@ -130,16 +144,22 @@ def _env_step(
     """Single environment step. Called via scan with closure wrapper."""
     train_state, env_state, last_obs, rng_step, rng_epoch = runner_state
 
-    # Use fold_in to generate unique key for this step, maintains shape
-    step_key, action_key = jax.random.split(rng_step)
+    # Split dedicated keys for action sampling and env stepping (a key must never be
+    # consumed by two different random consumers); step_key remains the scan carry.
+    step_key, action_key, env_key = jax.random.split(rng_step, 3)
 
     select_action_state = (action_key, env_state, last_obs)
     env_state, action, log_prob, value = jit_profiler.call(
         env_params.profile, select_action, select_action_state, env, env_params, train_state, config
     )
 
+    # Capture the acting state before env.step: on done steps env.step auto-resets, which
+    # would replace the action mask / valid mass actually used by select_action with the
+    # initial state's all-ones mask and valid_mass=1.0 in the stored transition.
+    acting_state = env_state.env_state
+
     obsv, env_state, reward, terminal, truncated, info = jit_profiler.call(
-        env_params.profile, env.step, action_key, env_state, action, env_params
+        env_params.profile, env.step, env_key, env_state, action, env_params
     )
     # Apply reward scaling if configured
     reward = reward * config.REWARD_SCALE
@@ -162,11 +182,11 @@ def _env_step(
             log_prob,
             last_obs,
             info,
-            env_state.env_state.node_mask_s,
-            env_state.env_state.link_slot_mask,
-            env_state.env_state.node_mask_d,
-            env_state.env_state.valid_mass,
-            env_state.env_state.link_slot_mask,
+            acting_state.node_mask_s,
+            acting_state.link_slot_mask,
+            acting_state.node_mask_d,
+            acting_state.valid_mass,
+            acting_state.link_slot_mask,
         )
     else:
         transition = RSATransition(
@@ -178,8 +198,8 @@ def _env_step(
             log_prob,
             last_obs,
             info,
-            env_state.env_state.link_slot_mask,
-            env_state.env_state.valid_mass,
+            acting_state.link_slot_mask,
+            acting_state.valid_mass,
         )
 
     # DEBUG LOGGING FOR OPTICAL NETWORKS
@@ -281,10 +301,17 @@ def _calculate_puffer_advantage(
     # Optionally anneal GAE_LAMBDA to higher value to increase horizon
     if config.GAE_LAMBDA is None:
         # Multiply by 3 so that more time spent in high lambda at end of training
+        # (denominator in train_state.step units: per gradient step if STEP_ON_GRADIENT,
+        # else per update loop)
         frac = (
             3
             * train_state.step
-            / (config.NUM_INCREMENTS * config.NUM_UPDATES * config.LAMBDA_SCHEDULE_MULTIPLIER)
+            / (
+                config.NUM_INCREMENTS
+                * config.NUM_UPDATES
+                * steps_per_train_state_unit(config)
+                * config.LAMBDA_SCHEDULE_MULTIPLIER
+            )
         )
         sech_frac = 1 - 1 / jnp.cosh(frac)
         lambda_delta = config.FINAL_LAMBDA - config.INITIAL_LAMBDA
@@ -298,11 +325,18 @@ def _calculate_puffer_advantage(
     ) -> Tuple[Tuple[Array, Array], Tuple[Array, Array]]:
         gae, next_value = gae_and_next_value
         transition, importance = transition_and_importance
-        terminal, value, reward = (
+        terminal, truncated, value, reward = (
             transition.terminal,
+            transition.truncated,
             transition.value,
             transition.reward,
         )
+        # env.step auto-resets on terminal OR truncated, so next_value at a truncation
+        # boundary is V(post-reset state) and credit must not flow across it. Masking the
+        # bootstrap with done treats truncation as termination (bootstrap 0 rather than
+        # V(pre-reset s_t+1)); the faithful alternative would require exposing the
+        # pre-reset final observation from env.step.
+        done = jnp.logical_or(terminal, truncated)
         centered_reward = reward - train_state.avg_reward if config.REWARD_CENTERING else reward
 
         if config.RHO_CLIP <= 0 or config.C_CLIP <= 0:
@@ -315,12 +349,12 @@ def _calculate_puffer_advantage(
             c_t = jnp.minimum(importance, config.C_CLIP)
 
         # Modified TD error calculation with importance sampling
-        # delta = rho_t * (r_t+1 + gamma * V(s_t+1) * (1 - terminal_t+1) - V(s_t))
-        delta = rho_t * (centered_reward + config.GAMMA * next_value * (1 - terminal) - value)
+        # delta = rho_t * (r_t+1 + gamma * V(s_t+1) * (1 - done_t+1) - V(s_t))
+        delta = rho_t * (centered_reward + config.GAMMA * next_value * (1 - done) - value)
 
         # Modified GAE accumulation with clipped importance ratios
-        # A_t = delta_t + gamma * lambda * c_t * (1 - terminal_t+1) * A_t+1
-        gae = delta + config.GAMMA * current_lambda * c_t * (1 - terminal) * gae
+        # A_t = delta_t + gamma * lambda * c_t * (1 - done_t+1) * A_t+1
+        gae = delta + config.GAMMA * current_lambda * c_t * (1 - done) * gae
 
         return (gae, value), (gae, delta)
 
@@ -428,9 +462,11 @@ def _env_rollout_advantages(
         else compute_trajectory_priority_weights(adv, train_state.prio_alpha)
     )
     # Anneal beta from initial value to 1.0 over course of training
-    progress = (
-        train_state.prio_alpha * train_state.step / (config.NUM_UPDATES * config.NUM_INCREMENTS)
+    # (denominator in train_state.step units; clip so beta never exceeds 1.0)
+    progress = train_state.step / (
+        config.NUM_UPDATES * config.NUM_INCREMENTS * steps_per_train_state_unit(config)
     )
+    progress = jnp.clip(progress, 0.0, 1.0)
     annealed_beta = train_state.prio_beta0 + (1.0 - train_state.prio_beta0) * progress
     train_state = eqx.tree_at(
         lambda state: state.prio_beta,

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Callable, Dict, Tuple, cast
 
 import distrax
@@ -535,15 +536,28 @@ def _loss_fn(
             path_log_prob = pi_masked.log_prob(path_actions)
             path_entropy = pi_masked.entropy()
 
-        path_indices = jax.vmap(process_path_action, in_axes=(0, None, 0))(
-            traj_batch.obs[0], config, path_actions
-        )[0]
-        # Re-scale action from [min_power, max_power] to [0, 1]
-        power_actions = jnp.astype(
-            (to_dbm(power_actions) - config.min_power) / config.step_power, jnp.int32
-        )
+        # Decode the k-path index from the flat action. process_path_action needs the env
+        # state and hashable static env_params, neither of which is available here; only
+        # the path index is needed, so mirror its decode directly (ceil matches
+        # init_link_slot_mask / aggregate_slots).
+        num_slot_actions = math.ceil(config.link_resources / config.aggregate_slots)
+        path_indices = (path_actions // num_slot_actions).astype(jnp.int32)
+        # Invert the sampling-time mapping (see LaunchPowerActorCriticMLP.sample_action):
+        # stored actions are linear-unit powers; recover the raw sample the distribution's
+        # log_prob expects (power-level index for discrete, [0, 1] Beta sample otherwise).
+        if config.discrete_launch_power:
+            power_actions = jnp.astype(
+                jnp.round((to_dbm(power_actions) - config.min_power) / config.step_power),
+                jnp.int32,
+            )
+        else:
+            power_actions = jnp.clip(
+                (to_dbm(power_actions) - config.min_power) / (config.max_power - config.min_power),
+                config.EPSILON,
+                1.0 - config.EPSILON,
+            )
         # Repeat the power action along the last axis K-paths time
-        power_actions = jnp.tile(power_actions[..., None], (1, config.k_paths))
+        power_actions = jnp.tile(power_actions[..., None], (1, config.k))
         power_log_prob = power_dist.log_prob(power_actions)
         # Select the chosen path's log prob / entropy, keeping shape (B,) to match
         # path_log_prob and the rollout-time stored log_prob (a (B,1)/(B,k) leftover here

--- a/xlron/train/ppo_test.py
+++ b/xlron/train/ppo_test.py
@@ -8,11 +8,21 @@ same distrax masking/log-prob ops as ``select_action_batched`` (rollout-time sto
 * recentered mode: ratio == 1 for every valid action (log ratio == 0)
 """
 
+from types import SimpleNamespace
+from typing import NamedTuple
+
 import chex
 import distrax
 import jax
 import jax.numpy as jnp
+import optax
 from absl.testing import absltest, parameterized
+from box import Box
+
+from xlron.environments.make_env import make
+from xlron.models.mlp import ActorCriticMLP
+from xlron.train.ppo import _calculate_puffer_advantage, _env_step, _sample_prioritized_batch
+from xlron.train.train_utils import TrainState
 
 LOGR_CLIP = 10.0
 
@@ -168,6 +178,190 @@ class ActorGradientEquivalenceTest(chex.TestCase):
         g_emergent = jax.grad(emergent_loss)(theta_old)
         g_explicit = jax.grad(explicit_loss)(theta_old)
         chex.assert_trees_all_close(g_emergent, g_explicit, atol=1e-5)
+
+
+class PrioritizedReplayWeightsTest(chex.TestCase):
+    """Regression for the PER importance weights in ``_sample_prioritized_batch``.
+
+    Standard PER (Schaul et al. 2016) uses w_i = (N * P(i))^-beta / max_i w_i. The old code
+    computed P(i)^-beta with no N factor and no max-normalization, so near-uniform priorities
+    gave weights ~N^beta (e.g. ~150x for N=300k, beta=0.4) instead of ~1, inflating the actor
+    surrogate relative to the uniform path (weights exactly 1.0) and to VF_COEF/ENT_COEF.
+    """
+
+    def _config(self, **overrides):
+        base = dict(
+            ROLLOUT_LENGTH=8,
+            NUM_ENVS=4,
+            NUM_MINIBATCHES=2,
+            MINIBATCH_SIZE=16,
+            NUM_LEARNERS=1,
+            PRIO_ALPHA=0.6,
+            PRIO_BETA0=0.4,
+            USE_RNN=False,
+            RHO_CLIP=0.0,
+            C_CLIP=0.0,
+        )
+        base.update(overrides)
+        return Box(base)
+
+    def _batch(self, config):
+        n = config.ROLLOUT_LENGTH * config.NUM_ENVS
+        arr = jnp.arange(n, dtype=jnp.float32).reshape(config.ROLLOUT_LENGTH, config.NUM_ENVS)
+        return (arr, arr + 100.0, arr - 100.0)
+
+    def test_uniform_priorities_give_unit_weights(self):
+        config = self._config()
+        priorities = jnp.ones((config.ROLLOUT_LENGTH, config.NUM_ENVS))
+        _, weights = _sample_prioritized_batch(
+            self._batch(config), priorities, jnp.array(0.4), jax.random.PRNGKey(0), config
+        )
+        # Uniform priorities must match the PRIO_ALPHA=0 path's scale (weights of exactly 1).
+        chex.assert_trees_all_close(weights, jnp.ones_like(weights), atol=1e-6)
+
+    def test_nonuniform_priorities_max_normalized(self):
+        config = self._config()
+        priorities = (
+            jnp.arange(1, config.ROLLOUT_LENGTH * config.NUM_ENVS + 1)
+            .astype(jnp.float32)
+            .reshape(config.ROLLOUT_LENGTH, config.NUM_ENVS)
+        )
+        _, weights = _sample_prioritized_batch(
+            self._batch(config), priorities, jnp.array(0.4), jax.random.PRNGKey(0), config
+        )
+        self.assertLessEqual(float(weights.max()), 1.0 + 1e-6)
+        # The rarest (lowest-priority) samples carry the largest correction weight = 1.
+        self.assertGreater(float(weights.max()), float(weights.min()))
+
+    def test_trajectory_branch_uniform_priorities_give_unit_weights(self):
+        config = self._config(USE_RNN=True, RHO_CLIP=1.0, C_CLIP=1.0)
+        priorities = jnp.ones((config.NUM_ENVS,))
+        _, weights = _sample_prioritized_batch(
+            self._batch(config), priorities, jnp.array(0.4), jax.random.PRNGKey(0), config
+        )
+        chex.assert_trees_all_close(weights, jnp.ones_like(weights), atol=1e-6)
+
+
+class _Traj(NamedTuple):
+    terminal: jnp.ndarray
+    truncated: jnp.ndarray
+    value: jnp.ndarray
+    reward: jnp.ndarray
+
+
+class AdvantageTruncationTest(chex.TestCase):
+    """Regression for GAE leakage across auto-reset (truncation) boundaries.
+
+    env.step auto-resets on terminal OR truncated, so at a truncated step value[t+1] is
+    V(post-reset state). The advantage recursion must therefore mask with done = terminal
+    OR truncated; masking with terminal alone bootstraps on the post-reset value and
+    propagates next-episode TD errors into the previous episode.
+    """
+
+    def _adv(self, rewards, values, truncated, last_value):
+        t = rewards.shape[0]
+        traj = _Traj(
+            terminal=jnp.zeros((t,), dtype=bool),
+            truncated=truncated,
+            value=values,
+            reward=rewards,
+        )
+        config = Box(
+            dict(GAE_LAMBDA=0.9, GAMMA=0.99, REWARD_CENTERING=False, RHO_CLIP=0.0, C_CLIP=0.0)
+        )
+        train_state = SimpleNamespace(step=jnp.array(0), avg_reward=jnp.array(0.0))
+        adv, _, _ = _calculate_puffer_advantage(
+            train_state, traj, last_value, jnp.ones_like(rewards), config
+        )
+        return adv
+
+    def test_no_credit_flows_across_truncation(self):
+        truncated = jnp.array([False, False, True, False, False, False])
+        rewards_a = jnp.array([1.0, 0.5, -1.0, 2.0, 3.0, 1.0])
+        values_a = jnp.array([0.3, 0.2, 0.1, 5.0, 4.0, 3.0])
+        # Same trajectory before the boundary, wildly different afterwards
+        rewards_b = rewards_a.at[3:].set(jnp.array([-7.0, 11.0, 0.0]))
+        values_b = values_a.at[3:].set(jnp.array([-2.0, 9.0, 1.0]))
+
+        adv_a = self._adv(rewards_a, values_a, truncated, jnp.array(2.0))
+        adv_b = self._adv(rewards_b, values_b, truncated, jnp.array(-5.0))
+
+        # Advantages up to and including the truncated step are independent of the next episode
+        chex.assert_trees_all_close(adv_a[:3], adv_b[:3], atol=1e-6)
+        # The truncated step must not bootstrap on the (post-reset) next value
+        chex.assert_trees_all_close(adv_a[2], rewards_a[2] - values_a[2], atol=1e-6)
+
+
+class TransitionMaskTest(chex.TestCase):
+    """Regression for the transition action_mask/valid_mass stored by ``_env_step``.
+
+    env.step auto-resets on done, replacing link_slot_mask with the initial all-ones mask
+    and valid_mass with 1.0. The transition must store the acting state's mask/valid mass
+    (as used by select_action), captured before env.step.
+    """
+
+    def test_truncated_step_stores_acting_mask(self):
+        settings = dict(
+            load=100,
+            k=2,
+            topology_name="4node",
+            link_resources=4,
+            max_requests=10,
+            mean_service_holding_time=10,
+            env_type="rwa",
+            values_bw=[1],
+            slot_size=1,
+            guardband=0,
+            continuous_operation=False,
+        )
+        env, params = make(settings, log_wrapper=True)
+        rng = jax.random.PRNGKey(0)
+        reset_key, step_key = jax.random.split(rng)
+        obs, env_state = env.reset(reset_key, params)
+
+        # Occupy all slots except slot 0 on every link (so the acting mask has zeros) and
+        # make this the final request of the episode (so env.step truncates + auto-resets).
+        inner = env_state.env_state
+        occupied = jnp.ones_like(inner.link_slot_array).at[:, 0].set(0)
+        inner = inner.replace(
+            link_slot_array=occupied,
+            total_requests=jnp.array(params.max_requests - 1, dtype=inner.total_requests.dtype),
+        )
+        env_state = env_state.replace(env_state=inner)
+        expected_mask = env.action_mask(inner, params)[0]  # ty: ignore[unresolved-attribute]
+        # Precondition: the acting mask is not the all-ones initial mask
+        self.assertFalse(bool(jnp.all(expected_mask == 1)))
+
+        model = ActorCriticMLP(
+            int(expected_mask.shape[-1]),
+            int(obs.shape[-1]),
+            num_layers=1,
+            num_units=16,
+            key=jax.random.PRNGKey(1),
+        )
+        train_state = TrainState.create(model, optax.adam(1e-3))
+        config = Box(
+            dict(
+                env_type="rwa",
+                USE_GNN=False,
+                USE_TRANSFORMER=False,
+                deterministic=False,
+                DEBUG=False,
+                REWARD_SCALE=1.0,
+            )
+        )
+
+        runner_state = (train_state, env_state, tuple([obs]), step_key, step_key)
+        runner_state, transition = _env_step(runner_state, None, env, params, config)
+
+        self.assertTrue(bool(transition.truncated))
+        # The stored mask is the acting mask, not the post-reset all-ones mask
+        chex.assert_trees_all_close(
+            transition.action_mask, expected_mask.astype(transition.action_mask.dtype)
+        )
+        self.assertFalse(bool(jnp.all(transition.action_mask == 1)))
+        # ... even though the post-step (reset) state carries the all-ones initial mask
+        self.assertTrue(bool(jnp.all(runner_state[1].env_state.link_slot_mask == 1)))
 
 
 if __name__ == "__main__":

--- a/xlron/train/ppo_test.py
+++ b/xlron/train/ppo_test.py
@@ -364,5 +364,45 @@ class TransitionMaskTest(chex.TestCase):
         self.assertTrue(bool(jnp.all(runner_state[1].env_state.link_slot_mask == 1)))
 
 
+class PowerHeadShapeTest(chex.TestCase):
+    """Regression for the chosen-path power log-prob/entropy selection in ``_loss_fn``.
+
+    The GNN power head is per-path: vmapped over the minibatch, power_dist has batch shape
+    (B, k). ``_loss_fn`` must reduce log_prob/entropy to shape (B,) for the chosen path.
+    The old vmapped ``dynamic_slice`` left log_prob at (B, 1) — silently broadcasting the
+    log-ratio to (B, B) — and never reduced entropy from (B, k).
+    """
+
+    def test_chosen_path_selection_shapes_and_values(self):
+        b, k, levels = 5, 3, 4
+        key = jax.random.PRNGKey(0)
+        logits = jax.random.normal(key, (b, k, levels))
+        power_dist = distrax.Categorical(logits=logits)
+        power_actions = jnp.tile(jnp.array([0, 1, 2, 3, 0])[:, None], (1, k))  # (B, k)
+        path_indices = jnp.array([0, 1, 2, 0, 1])
+        stored_log_prob = jnp.zeros((b,))  # rollout-time log_prob is (B,)
+
+        power_log_prob = power_dist.log_prob(power_actions)  # (B, k)
+        # The fixed selection used in _loss_fn
+        selected_lp = jnp.take_along_axis(power_log_prob, path_indices[:, None], axis=1)[:, 0]
+        selected_ent = jnp.take_along_axis(power_dist.entropy(), path_indices[:, None], axis=1)[
+            :, 0
+        ]
+        self.assertEqual(selected_lp.shape, (b,))
+        self.assertEqual(selected_ent.shape, (b,))
+        self.assertEqual((selected_lp - stored_log_prob).shape, (b,))  # log-ratio stays (B,)
+        expected = jnp.stack(
+            [power_dist.log_prob(power_actions)[i, path_indices[i]] for i in range(b)]
+        )
+        chex.assert_trees_all_close(selected_lp, expected, atol=1e-6)
+
+        # The old construction yields (B, 1): the log-ratio silently broadcasts to (B, B).
+        old = jax.vmap(lambda x, i: jax.lax.dynamic_slice(x, (i,), (1,)))(
+            power_log_prob, path_indices
+        )
+        self.assertEqual(old.shape, (b, 1))
+        self.assertEqual((old - stored_log_prob).shape, (b, b))
+
+
 if __name__ == "__main__":
     absltest.main()

--- a/xlron/train/train.py
+++ b/xlron/train/train.py
@@ -712,7 +712,7 @@ def train(argv: list[str], config: Dict[str, Any] = {}) -> None:
             )
             # Save model params (skip if EVAL_DURING_TRAINING, which saves only the best model)
             if config.SAVE_MODEL and not config.EVAL_DURING_TRAINING:
-                train_state = out["runner_state"][0]  # Get TrainState from the first learner
+                train_state = out["runner_state"][0]  # TrainState element of the runner-state tuple
                 # Determine current metric value to decide whether to save
                 if config.continuous_operation:
                     if config.reward_type == "bitrate":
@@ -734,7 +734,13 @@ def train(argv: list[str], config: Dict[str, Any] = {}) -> None:
                         )
                 if current_metric <= best_eval_metric:
                     best_eval_metric = current_metric
-                    model = eqx.combine(train_state.model_params, train_state.model_static)
+                    model_params = train_state.model_params
+                    if config.NUM_LEARNERS > 1:
+                        # vmap over the learner axis stacks every param leaf to
+                        # [NUM_LEARNERS, ...]; save learner 0's weights so the checkpoint
+                        # matches the unbatched template used by load_model.
+                        model_params = jax.tree.map(lambda x: x[0], model_params)
+                    model = eqx.combine(model_params, train_state.model_static)
                     saved_path = save_model(model, config, first_save=first_save)
                     if first_save:
                         config.MODEL_PATH = str(saved_path)

--- a/xlron/train/train_smoke_test.py
+++ b/xlron/train/train_smoke_test.py
@@ -1,0 +1,61 @@
+"""End-to-end CPU training smoke tests for the RL launch-power path.
+
+Regression cover for the launch_power_type="rl" training path, which rotted invisibly
+because nothing exercised the full train pipeline (init_network -> warmup/select_action
+-> rollout -> _loss_fn) with a GN-model env. Each test runs the real entry point in a
+subprocess with a tiny config; a clean exit is the assertion. Marked slow (~20s each,
+dominated by XLA compilation): deselect with `pytest -m "not slow"`.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+BASE_ARGS = [
+    "-m",
+    "xlron.train.train",
+    "--env_type=rsa_gn_model",
+    "--topology_name=nsfnet_deeprmsa_directed",
+    "--link_resources=10",
+    "--k=4",
+    "--values_bw=100",
+    "--incremental_loading",
+    "--slot_size=12.5",
+    "--guardband=0",
+    "--launch_power_type=rl",
+    "--ROLLOUT_LENGTH=10",
+    "--TOTAL_TIMESTEPS=20",
+    "--NUM_ENVS=1",
+    "--ENV_WARMUP_STEPS=0",
+]
+
+
+def _run_train(extra_args=()):
+    env = dict(os.environ, JAX_PLATFORMS="cpu")
+    result = subprocess.run(
+        [sys.executable, *BASE_ARGS, *extra_args],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"training run failed (exit {result.returncode})\n"
+        f"--- stdout tail ---\n{result.stdout[-3000:]}\n"
+        f"--- stderr tail ---\n{result.stderr[-3000:]}"
+    )
+    return result
+
+
+@pytest.mark.slow
+def test_launch_power_rl_training_smoke_continuous():
+    """MLP power-only policy with the continuous (Beta) power head (the default)."""
+    _run_train()
+
+
+@pytest.mark.slow
+def test_launch_power_rl_training_smoke_discrete():
+    """MLP power-only policy with the discrete (Categorical) power head."""
+    _run_train(["--discrete_launch_power"])

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -624,11 +624,13 @@ def init_network(config: Box, key: chex.PRNGKey) -> eqx.Module:
                 actor_pooling=config.transformer_actor_pooling,
             )
         elif config.USE_GNN:
-            if "gn_model" in config.env_type.lower() and config.output_globals_size_actor > 0:
+            if "gn_model" in config.env_type.lower() and config.global_output_size_actor > 0:
+                # Discrete: one logit per power level. Continuous: 2 outputs (alpha, beta) for
+                # the Beta distribution.
                 global_output_size_actor = (
                     int((config.max_power - config.min_power) / config.step_power) + 1
                     if config.discrete_launch_power
-                    else 1
+                    else 2
                 )
             else:
                 global_output_size_actor = config.global_output_size_actor
@@ -680,10 +682,10 @@ def init_network(config: Box, key: chex.PRNGKey) -> eqx.Module:
                 vmap=False,
                 key=key,
             )
-        elif "gn_model" in config.env_type.lower() and config.launch_power_type == 3:
+        elif "gn_model" in config.env_type.lower() and config.launch_power_type == "rl":
             network = LaunchPowerActorCriticMLP(
-                config.INPUT_DIM,
                 config.ACTION_DIM + (1 * config.include_no_op),  # +1 for "no op"
+                config.INPUT_DIM,
                 activation=config.ACTIVATION,
                 num_layers=config.NUM_LAYERS,
                 num_units=config.NUM_UNITS,
@@ -932,6 +934,18 @@ def cast_model_for_compute(model: eqx.Module) -> eqx.Module:
     )
 
 
+def _as_launch_power_array(power_action: Array, env_params) -> Array:
+    """Normalise a sampled power action to the carried launch_power_array format.
+
+    The carried array is shape (k_paths,) at LARGE_FLOAT_DTYPE (see make_env.py); sampled
+    powers may be scalar (global head), (1,) (fixed default) or (k_paths,) (per-path head),
+    so broadcast and cast to keep the lax.scan carry shape/dtype stable.
+    """
+    return jnp.broadcast_to(power_action.reshape(-1), (env_params.k_paths,)).astype(
+        dtype_config.LARGE_FLOAT_DTYPE
+    )
+
+
 def select_action(select_action_state, env, env_params, train_state, config):
     """Select an action from the policy.
     If using VONE, the action is a tuple of (source, path, destination).
@@ -1008,40 +1022,59 @@ def select_action(select_action_state, env, env_params, train_state, config):
         valid_mass = jnp.sum(probs * action_mask, axis=-1)
 
     elif "gn_model" in config.env_type.lower() and config.launch_power_type == "rl":
-        pi_masked = distrax.Categorical(
-            logits=pi[0]._logits + (-1e8 * (1 - action_mask.astype(jnp.float32)))
-        )
+        # Sampling dispatches to the model's own sample_action* methods (the models know how
+        # to convert raw samples to power levels); LaunchPowerActorCriticMLP returns
+        # (None, power_dist) so the path logits/mask only exist when the GNN outputs RSA.
         if config.GNN_OUTPUT_RSA and not config.GNN_OUTPUT_LP:
-            path_action, log_prob = train_state.sample_fn(
+            pi_masked = distrax.Categorical(
+                logits=pi[0]._logits + (-1e8 * (1 - action_mask.astype(jnp.float32)))
+            )
+            path_action, log_prob = model.sample_action_path(  # ty: ignore[unresolved-attribute]
                 action_key, pi_masked, log_prob=True, deterministic=config.deterministic
             )
             power_action = jnp.array([env_params.default_launch_power])
         elif config.GNN_OUTPUT_RSA and config.GNN_OUTPUT_LP:
-            path_action, power_action, log_prob = train_state.sample_fn(
+            pi_masked = distrax.Categorical(
+                logits=pi[0]._logits + (-1e8 * (1 - action_mask.astype(jnp.float32)))
+            )
+            path_action, power_action, log_prob = model.sample_action_path_power(  # ty: ignore[unresolved-attribute]
                 action_key,
                 (pi_masked, pi[1]),
                 log_prob=True,
                 deterministic=config.deterministic,
             )
         else:
-            power_action, log_prob = train_state.sample_fn(
+            # Power-only policy: path selected by heuristic (needs launch power set first)
+            power_sample_fn = getattr(model, "sample_action_power", model.sample_action)  # ty: ignore[unresolved-attribute]
+            power_action, log_prob = power_sample_fn(
                 action_key, pi[1], log_prob=True, deterministic=config.deterministic
             )
-            inner_state = env_state.env_state.replace(launch_power_array=power_action)
+            inner_state = env_state.env_state.replace(
+                launch_power_array=_as_launch_power_array(power_action, env_params)
+            )
             env_state = env_state.replace(env_state=inner_state)
             path_action = (
                 ksp_lf(env_state.env_state, env_params)
                 if env_params.last_fit is True
                 else ksp_ff(env_state.env_state, env_params)
             )
-        inner_state = env_state.env_state.replace(launch_power_array=power_action)
+        inner_state = env_state.env_state.replace(
+            launch_power_array=_as_launch_power_array(power_action, env_params)
+        )
         env_state = env_state.replace(env_state=inner_state)
-        if config.output_globals_size_actor == 0:
+        if config.global_output_size_actor == 0 and (
+            config.GNN_OUTPUT_LP or not config.GNN_OUTPUT_RSA
+        ):
+            # Per-path power head: keep only the sampled path's power/log_prob
             path_index, _ = process_path_action(env_state.env_state, env_params, path_action)
             power_action, log_prob = power_action[path_index], log_prob[path_index]
         action = jnp.concatenate([path_action.reshape((1,)), power_action.reshape((1,))], axis=0)  # ty: ignore[unresolved-attribute]
-        probs = jax.nn.softmax(pi[0]._logits, axis=-1)
-        valid_mass = jnp.sum(probs * action_mask, axis=-1)
+        if config.GNN_OUTPUT_RSA:
+            probs = jax.nn.softmax(pi[0]._logits, axis=-1)
+            valid_mass = jnp.sum(probs * action_mask, axis=-1)
+        else:
+            # No learned path policy: the heuristic path choice is always valid
+            valid_mass = jnp.array(1.0, dtype=dtype_config.LARGE_FLOAT_DTYPE)
 
     else:
         pi_masked = distrax.Categorical(
@@ -1639,9 +1672,11 @@ def process_metrics(config, out, merge_func):
         num_learners_or_1 = config.NUM_LEARNERS if config.NUM_LEARNERS > 1 else 1
         merged_out_loss = {
             k: jax.tree.map(
-                lambda x: x.reshape((num_learners_or_1, config.NUM_UPDATES, -1))
-                .mean(axis=-1)
-                .reshape((-1,)),
+                lambda x: (
+                    x.reshape((num_learners_or_1, config.NUM_UPDATES, -1))
+                    .mean(axis=-1)
+                    .reshape((-1,))
+                ),
                 v,
             )
             for k, v in out.get("loss_info", {}).items()

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -1600,7 +1600,13 @@ def run_eval_during_training(
         best_eval_metric = eval_metric_mean
         print(f"New best eval {eval_metric_name}: {best_eval_metric:.6f}")
         if config.SAVE_MODEL:
-            model = eqx.combine(current_train_state.model_params, current_train_state.model_static)
+            model_params = current_train_state.model_params
+            if config.NUM_LEARNERS > 1:
+                # vmap over the learner axis stacks every param leaf to [NUM_LEARNERS, ...];
+                # save learner 0's weights so the checkpoint matches the unbatched template
+                # used by load_model.
+                model_params = jax.tree.map(lambda x: x[0], model_params)
+            model = eqx.combine(model_params, current_train_state.model_static)
             saved_path = save_model(model, config, first_save=first_save)
             if first_save:
                 config.MODEL_PATH = str(saved_path)

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -1178,7 +1178,9 @@ def get_warmup_fn(warmup_state, env, params, train_state, config) -> Callable[[T
                 action_mask = mask_result[0]
                 action = jax.random.categorical(action_key, jnp.log(jnp.maximum(action_mask, 1e-8)))
             else:
-                select_action_state = (_rng, _state, _last_obs)
+                # Pass the dedicated action_key, not the loop-carry _rng (which is re-split
+                # next iteration and must never also be consumed for sampling).
+                select_action_state = (action_key, _state, _last_obs)
                 action_fn = select_action if not use_heuristic_warmup else select_action_eval
                 _state, action, log_prob, value = action_fn(
                     select_action_state, env, _params, _train_state, config
@@ -1228,6 +1230,19 @@ def get_warmup_fn(warmup_state, env, params, train_state, config) -> Callable[[T
         return vals[1], vals[4]
 
     return warmup_fn
+
+
+def steps_per_train_state_unit(config: Box) -> int:
+    """Number of train_state.step increments per update loop.
+
+    train_state.step increments once per gradient (minibatch) step when STEP_ON_GRADIENT
+    is set, otherwise once per update loop. Any schedule or anneal evaluated at
+    train_state.step (entropy/VML schedules, GAE-lambda and prio-beta anneals) must scale
+    its horizon by this factor so it completes exactly at the end of training. The LR
+    schedules are exempt: they are driven by optax's internal count, which always ticks
+    once per tx.update (i.e. per minibatch).
+    """
+    return config.UPDATE_EPOCHS * config.NUM_MINIBATCHES if config.STEP_ON_GRADIENT else 1
 
 
 def _make_schedule(
@@ -1358,14 +1373,15 @@ def make_ent_schedule(config: Box) -> optax.Schedule:
 
     ENT_COEF = config.ENT_COEF
     ENT_END_FRACTION = config.ENT_END_FRACTION
-    NUM_MINIBATCHES = config.NUM_MINIBATCHES
     NUM_UPDATES = config.NUM_UPDATES * config.NUM_INCREMENTS
-    UPDATE_EPOCHS = config.UPDATE_EPOCHS
+    # Evaluated at train_state.step (not optax's per-minibatch count), so the horizon
+    # must use the train_state.step unit.
+    STEPS_PER_UNIT = steps_per_train_state_unit(config)
     SCHEDULE_MULTIPLIER = config.ENT_SCHEDULE_MULTIPLIER
     end_value = ENT_COEF * ENT_END_FRACTION
 
     def ent_schedule(count: chex.Numeric) -> chex.Numeric:
-        total_steps = NUM_UPDATES * UPDATE_EPOCHS * NUM_MINIBATCHES * SCHEDULE_MULTIPLIER
+        total_steps = NUM_UPDATES * STEPS_PER_UNIT * SCHEDULE_MULTIPLIER
         if config.ENT_SCHEDULE == "cosine":
             schedule = optax.cosine_decay_schedule(
                 init_value=ENT_COEF,
@@ -1392,14 +1408,15 @@ def make_vml_schedule(config: Box) -> optax.Schedule:
 
     VML_COEF = config.VALID_MASS_LOSS_COEF
     VML_END_FRACTION = config.VML_END_FRACTION
-    NUM_MINIBATCHES = config.NUM_MINIBATCHES
     NUM_UPDATES = config.NUM_UPDATES * config.NUM_INCREMENTS
-    UPDATE_EPOCHS = config.UPDATE_EPOCHS
+    # Evaluated at train_state.step (not optax's per-minibatch count), so the horizon
+    # must use the train_state.step unit.
+    STEPS_PER_UNIT = steps_per_train_state_unit(config)
     SCHEDULE_MULTIPLIER = config.VML_SCHEDULE_MULTIPLIER
     end_value = VML_COEF * VML_END_FRACTION
 
     def vml_schedule(count: chex.Numeric) -> chex.Numeric:
-        total_steps = NUM_UPDATES * UPDATE_EPOCHS * NUM_MINIBATCHES * SCHEDULE_MULTIPLIER
+        total_steps = NUM_UPDATES * STEPS_PER_UNIT * SCHEDULE_MULTIPLIER
         if config.VML_SCHEDULE == "cosine":
             schedule = optax.cosine_decay_schedule(
                 init_value=VML_COEF,
@@ -1639,9 +1656,11 @@ def process_metrics(config, out, merge_func):
         num_learners_or_1 = config.NUM_LEARNERS if config.NUM_LEARNERS > 1 else 1
         merged_out_loss = {
             k: jax.tree.map(
-                lambda x: x.reshape((num_learners_or_1, config.NUM_UPDATES, -1))
-                .mean(axis=-1)
-                .reshape((-1,)),
+                lambda x: (
+                    x.reshape((num_learners_or_1, config.NUM_UPDATES, -1))
+                    .mean(axis=-1)
+                    .reshape((-1,))
+                ),
                 v,
             )
             for k, v in out.get("loss_info", {}).items()

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -694,7 +694,7 @@ def init_network(config: Box, key: chex.PRNGKey) -> eqx.Module:
                 min_power_dbm=config.min_power,
                 max_power_dbm=config.max_power,
                 step_power_dbm=config.step_power,
-                k_paths=config.k_paths,
+                k_paths=config.k,
                 key=key,
             )
         else:

--- a/xlron/train/train_utils_test.py
+++ b/xlron/train/train_utils_test.py
@@ -1,0 +1,75 @@
+"""Unit tests for training utilities: schedule step-unit consistency and checkpointing.
+
+The entropy/VML schedules are evaluated at ``train_state.step``, which increments once per
+update loop by default and once per gradient (minibatch) step when STEP_ON_GRADIENT is set.
+Their horizons must be expressed in the same unit or the schedules never complete (default)
+or complete UPDATE_EPOCHS*NUM_MINIBATCHES times too early (STEP_ON_GRADIENT). The LR
+schedules are exempt: optax drives them with its internal per-tx.update count.
+"""
+
+import chex
+import jax.numpy as jnp
+from absl.testing import absltest, parameterized
+from box import Box
+
+from xlron.train.train_utils import (
+    make_ent_schedule,
+    make_vml_schedule,
+    steps_per_train_state_unit,
+)
+
+
+def _schedule_config(step_on_gradient):
+    return Box(
+        dict(
+            NUM_UPDATES=10,
+            NUM_INCREMENTS=2,
+            UPDATE_EPOCHS=4,
+            NUM_MINIBATCHES=4,
+            STEP_ON_GRADIENT=step_on_gradient,
+            ENT_COEF=0.01,
+            ENT_END_FRACTION=0.1,
+            ENT_SCHEDULE="linear",
+            ENT_SCHEDULE_MULTIPLIER=1.0,
+            VALID_MASS_LOSS_COEF=0.5,
+            VML_END_FRACTION=0.2,
+            VML_SCHEDULE="linear",
+            VML_SCHEDULE_MULTIPLIER=1.0,
+        )
+    )
+
+
+class ScheduleStepUnitTest(chex.TestCase):
+    @parameterized.named_parameters(
+        ("per_update_loop", False),
+        ("per_gradient_step", True),
+    )
+    def test_ent_schedule_completes_at_end_of_training(self, step_on_gradient):
+        config = _schedule_config(step_on_gradient)
+        final_step = config.NUM_UPDATES * config.NUM_INCREMENTS * steps_per_train_state_unit(config)
+        ent_schedule = make_ent_schedule(config)
+        chex.assert_trees_all_close(
+            ent_schedule(final_step),
+            jnp.array(config.ENT_COEF * config.ENT_END_FRACTION),
+            atol=1e-8,
+        )
+        # And the start of training is the initial coefficient
+        chex.assert_trees_all_close(ent_schedule(0), jnp.array(config.ENT_COEF), atol=1e-8)
+
+    @parameterized.named_parameters(
+        ("per_update_loop", False),
+        ("per_gradient_step", True),
+    )
+    def test_vml_schedule_completes_at_end_of_training(self, step_on_gradient):
+        config = _schedule_config(step_on_gradient)
+        final_step = config.NUM_UPDATES * config.NUM_INCREMENTS * steps_per_train_state_unit(config)
+        vml_schedule = make_vml_schedule(config)
+        chex.assert_trees_all_close(
+            vml_schedule(final_step),
+            jnp.array(config.VALID_MASS_LOSS_COEF * config.VML_END_FRACTION),
+            atol=1e-8,
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/xlron/train/train_utils_test.py
+++ b/xlron/train/train_utils_test.py
@@ -7,11 +7,16 @@ or complete UPDATE_EPOCHS*NUM_MINIBATCHES times too early (STEP_ON_GRADIENT). Th
 schedules are exempt: optax drives them with its internal per-tx.update count.
 """
 
+import io
+
 import chex
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 from absl.testing import absltest, parameterized
 from box import Box
 
+from xlron.models.mlp import ActorCriticMLP
 from xlron.train.train_utils import (
     make_ent_schedule,
     make_vml_schedule,
@@ -68,6 +73,45 @@ class ScheduleStepUnitTest(chex.TestCase):
             vml_schedule(final_step),
             jnp.array(config.VALID_MASS_LOSS_COEF * config.VML_END_FRACTION),
             atol=1e-8,
+        )
+
+
+class LearnerStackedCheckpointTest(chex.TestCase):
+    """Regression for saving models with NUM_LEARNERS > 1.
+
+    vmapping experiment_data_setup over the learner axis stacks every param leaf to
+    [NUM_LEARNERS, ...]. Serialising the stacked params produces a checkpoint that cannot
+    be deserialised into the unbatched template used by load_model; the save path must
+    unreplicate (take learner 0) first.
+    """
+
+    def _model(self, key):
+        return ActorCriticMLP(4, 8, num_layers=1, num_units=8, key=key)
+
+    def test_unreplicated_params_roundtrip(self):
+        keys = jax.random.split(jax.random.PRNGKey(0), 2)
+        params_static = [eqx.partition(self._model(k), eqx.is_inexact_array) for k in keys]
+        static = params_static[0][1]
+        stacked = jax.tree.map(
+            lambda a, b: jnp.stack([a, b]), params_static[0][0], params_static[1][0]
+        )
+        template = self._model(jax.random.PRNGKey(1))
+
+        # Stacked (buggy) checkpoint cannot be loaded into the unbatched template
+        buf = io.BytesIO()
+        eqx.tree_serialise_leaves(buf, eqx.combine(stacked, static))
+        buf.seek(0)
+        with self.assertRaises(Exception):
+            eqx.tree_deserialise_leaves(buf, template)
+
+        # Unreplicated (fixed) checkpoint round-trips to learner 0's weights
+        buf = io.BytesIO()
+        unreplicated = jax.tree.map(lambda x: x[0], stacked)
+        eqx.tree_serialise_leaves(buf, eqx.combine(unreplicated, static))
+        buf.seek(0)
+        restored = eqx.tree_deserialise_leaves(buf, template)
+        chex.assert_trees_all_close(
+            eqx.partition(restored, eqx.is_inexact_array)[0], params_static[0][0]
         )
 
 


### PR DESCRIPTION
## Summary

Completes the repair of the `--launch_power_type=rl` RL-training path for GN-model environments. On `main` this mode is dead at trace time; the models-bundle PR restored `LaunchPowerActorCriticMLP` construction and the `select_action` sampling dispatch (replacing the nonexistent `train_state.sample_fn` with the models' own `sample_action*` methods, adding the `GNN_OUTPUT_RSA` guard and the None-safe `valid_mass` fallback), and the ppo-bundle PR fixed the RL-power `_loss_fn` shapes. This PR fixes what still crashed after those two, so a full PPO update now trains end-to-end.

> **Stacking:** this branch is `claude/models` merged with `claude/ppo` plus these commits. **It must merge after both the models PR and the ppo PR.** The `RSAGNModelEnv.get_obs` fix is byte-identical to the one in the gn-physics PR so the two merge cleanly whichever lands first.

## Fixes

- **`init_network` (train_utils.py):** read `config.k` — the actual config key, synced to `env_params.k_paths` in `experiment_data_setup` — instead of the nonexistent `config.k_paths`, which raised `BoxKeyError` before the launch-power MLP was even built.
- **`RSAGNModelEnv.get_obs` (rsa_gn_model.py):** return `get_paths_obs_gn_model` (4 + 7·k_paths features, matching `observation_space` and `RMSAGNModelEnv`) instead of the 0-d scalar stub, which crashed any flat-obs model at trace time.
- **`_loss_fn` RL-power branch (ppo.py):**
  - Decode the k-path index arithmetically from the flat action. The old code passed the (unhashable) `Box` config as `process_path_action`'s static `env_params` — a guaranteed trace-time `ValueError` — and the obs array as its env state.
  - Invert the sampling-time power mapping per head type: discrete → round to a power-level index for `Categorical.log_prob`; continuous (the default) → rescale to the clipped `[0, 1]` sample for `Beta.log_prob`. Previously the discrete formula ran unconditionally, feeding raw integer indices to the Beta distribution.
  - `config.k_paths` → `config.k` in the per-path tile width.

## Behavior changes

- `RSAGNModelEnv.get_obs` now computes the full path-statistics observation every step instead of returning a scalar placeholder. Any run that steps this env (including heuristic eval) pays that per-step cost; XLA dead-code-elimination removes it where the obs is genuinely unused. Values feeding models/logs from this env's obs change from `0` to real features.
- `_loss_fn` power log-probs/entropy for the continuous Beta head are now computed on the correct `[0, 1]` support — gradients for `launch_power_type=rl` training change (from meaningless/NaN-prone to correct).
- No change to any non-GN-model env, to `launch_power_type` fixed/tabular/scaled, or to heuristic evaluation semantics.

## Tests

- New `xlron/train/train_smoke_test.py`: CPU subprocess training-smoke tests for `launch_power_type=rl` with the continuous and discrete power heads (the exact command below, tiny config), marked `slow` (registered marker; deselect with `-m "not slow"`).
- Updated `InitNetworkDispatchTest` for the `k` config key and asserts the constructed `k_paths`.
- Suites run green on CPU: models_test, ppo_test, train_utils_test, make_env_test (39 passed), gn_model_test (39 passed, 6 skipped), train_smoke_test (2 passed).

## Verification

```
uv run python -m xlron.train.train --env_type=rsa_gn_model --topology_name=nsfnet_deeprmsa_directed \
  --link_resources=10 --k=4 --values_bw=100 --incremental_loading --slot_size=12.5 --guardband=0 \
  --launch_power_type=rl --ROLLOUT_LENGTH=10 --TOTAL_TIMESTEPS=20 --NUM_ENVS=1 --ENV_WARMUP_STEPS=0
```

Exits 0 with sane metrics (4/4 services accepted, no NaNs); the `--discrete_launch_power` variant also passes.

**Known unrelated failure:** `--USE_GNN` with `rsa_gn_model` fails with `dot_general requires contracting dimensions to have the same shape, got (10,) and (20,)` in the GNN edge embedder. This reproduces identically with `--launch_power_type=fixed`, i.e. it is a pre-existing GN-model+GNN edge-feature sizing bug (the embedder is sized to `link_resources` but GN-model graph edges carry 2× that), out of scope here.

---
*Follow-up to the 13-PR review batch, requested as a dedicated task. Adversarially reviewed; e2e-verified on CPU for both power heads.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)