### PR TITLE
Fix GNN models on GN-model environments (edge-feature sizing + fixed-power path)

### DIFF
--- a/xlron/environments/wrappers.py
+++ b/xlron/environments/wrappers.py
@@ -2,7 +2,7 @@ import time
 import timeit
 from collections import defaultdict
 from functools import partial
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Optional, Tuple, Union, cast
 
 import chex
 import jax
@@ -103,9 +103,20 @@ class LogWrapper(GymnaxWrapper):
         # First check if we're dealing with RSAGNModelEnvParams
         is_gn_params = isinstance(params, RSAGNModelEnvParams)
 
-        # For RSA params, unpack the action
+        # For RSA params, unpack the action. The action is [path_slot_action, launch_power]
+        # when the RL agent controls launch power, or a bare path_slot_action otherwise
+        # (e.g. GNN path policy with fixed launch power) - mirror process_action's handling.
         if is_gn_params:
-            action, power_action = action
+            action = jnp.atleast_1d(action)
+            power_action = (
+                action[1]
+                if action.shape[0] > 1
+                else jnp.asarray(
+                    cast(RSAGNModelEnvParams, params).default_launch_power,
+                    dtype=dtype_config.LARGE_FLOAT_DTYPE,
+                )
+            )
+            action = action[0]
             info["launch_power"] = power_action
 
         # Now, if we need to log actions OR we have RSA params, compute the common fields

--- a/xlron/models/gnn.py
+++ b/xlron/models/gnn.py
@@ -990,7 +990,14 @@ class ActorGNN(eqx.Module):
         path_action_dist = distrax.Categorical(logits=path_action_logits)
 
         power_action_dist = None
-        if params.__class__.__name__ == "RSAGNModelEnvParams":
+        # Only output a launch-power distribution when the RL agent controls launch power.
+        # launch_power_type is a static (pytree_node=False) str field on GNModelEnvParams,
+        # so this branch is resolved at trace time. With fixed/tabular/scaled launch power,
+        # downstream select_action/_loss_fn expect a bare path distribution.
+        if (
+            params.__class__.__name__ in ("RSAGNModelEnvParams", "RMSAGNModelEnvParams")
+            and getattr(params, "launch_power_type", None) == "rl"
+        ):
             if self.global_output_size > 0:
                 power_logits = processed_graph.globals.reshape((-1,)) / self.temperature  # ty: ignore[unresolved-attribute]
             else:

--- a/xlron/models/models_test.py
+++ b/xlron/models/models_test.py
@@ -1,0 +1,136 @@
+"""Regression tests for neural network model construction and forward passes.
+
+GNN + GN-model envs: ``init_graph_tuple``/``update_graph_tuple`` build ``graph.edges``
+as ``stack([normalized_snr, normalized_power], axis=-1)`` -> shape (E, S, 2), which
+``GraphNet.__call__`` flattens to 2*link_resources features per edge. ``init_network``
+must size the GNN edge embedder from the same rule (previously it hardcoded
+``link_resources``, crashing at trace time with a dot_general contracting-dimension
+mismatch for any ``--USE_GNN`` + GN-model run).
+"""
+
+import chex
+import distrax
+import jax
+from absl import flags
+from absl.testing import absltest
+
+import xlron.parameter_flags  # noqa: F401  (registers all XLRON flags)
+from xlron.environments.make_env import make, process_config
+from xlron.train.train_utils import init_network
+
+
+def _flag_defaults() -> dict:
+    """Full config dict from the registered absl flag defaults."""
+    f = flags.FLAGS
+    defaults = {}
+    for name in f:
+        try:
+            defaults[name] = f[name].default
+        except Exception:
+            continue
+    return defaults
+
+
+def _gnn_env_setup(env_type: str, **overrides):
+    """Tiny env + processed config for GNN model construction tests."""
+    cfg = _flag_defaults()
+    cfg.update(
+        env_type=env_type,
+        topology_name="nsfnet_deeprmsa_directed",
+        link_resources=10,
+        k=4,
+        values_bw=[100],
+        incremental_loading=True,
+        slot_size=12.5,
+        guardband=0,
+        ROLLOUT_LENGTH=10,
+        TOTAL_TIMESTEPS=20,
+        STEPS_PER_INCREMENT=10,
+        NUM_ENVS=1,
+        ENV_WARMUP_STEPS=0,
+        USE_GNN=True,
+    )
+    cfg.update(overrides)
+    config = process_config(cfg)
+    env, params = make(config, log_wrapper=False)
+    key = jax.random.PRNGKey(0)
+    obs, state = env.reset(key, params)
+    return config, env, params, state, key
+
+
+class GNNModelConstructionTest(chex.TestCase):
+    """GNN model construction + forward pass on GN-model and plain RSA envs."""
+
+    def _build_and_forward(self, env_type: str, **overrides):
+        config, env, params, state, key = _gnn_env_setup(env_type, **overrides)
+        model = init_network(config, key)
+        pi, value = model(state, params)
+        return config, params, state, model, pi, value
+
+    def test_rsa_gn_model_edge_embedder_width(self):
+        """GN-model graph edges are (E, S, 2); embedder input must be 2*link_resources."""
+        config, params, state, model, pi, value = self._build_and_forward("rsa_gn_model")
+        # The env builds stacked [snr, power] per-slot edge features
+        self.assertEqual(
+            state.graph.edges.shape,
+            (params.num_links, config.link_resources, 2),
+        )
+        # The edge embedder must accept the flattened width
+        self.assertEqual(
+            model.actor.graph_net.edge_embedder.weight.shape[1],
+            2 * config.link_resources,
+        )
+        self.assertEqual(
+            model.critic.graph_net.edge_embedder.weight.shape[1],
+            2 * config.link_resources,
+        )
+
+    def test_rsa_gn_model_fixed_power_forward(self):
+        """With fixed launch power the actor returns a bare path distribution."""
+        config, params, state, model, pi, value = self._build_and_forward("rsa_gn_model")
+        self.assertIsInstance(pi, distrax.Categorical)
+        expected_actions = config.k * -(-config.link_resources // config.aggregate_slots)
+        self.assertEqual(pi.logits.shape, (expected_actions + int(params.include_no_op),))
+        chex.assert_tree_all_finite(pi.logits)
+        chex.assert_tree_all_finite(value)
+
+    def test_rsa_gn_model_rl_power_forward(self):
+        """With RL launch power the actor returns (path_dist, power_dist)."""
+        config, params, state, model, pi, value = self._build_and_forward(
+            "rsa_gn_model", launch_power_type="rl"
+        )
+        self.assertIsInstance(pi, tuple)
+        path_dist, power_dist = pi
+        self.assertIsInstance(path_dist, distrax.Categorical)
+        self.assertIsNotNone(power_dist)
+        chex.assert_tree_all_finite(path_dist.logits)
+
+    def test_rmsa_gn_model_forward(self):
+        """RMSA GN-model envs use the same stacked edge features."""
+        config, params, state, model, pi, value = self._build_and_forward("rmsa_gn_model")
+        self.assertEqual(
+            model.actor.graph_net.edge_embedder.weight.shape[1],
+            2 * config.link_resources,
+        )
+        self.assertIsInstance(pi, distrax.Categorical)
+        chex.assert_tree_all_finite(pi.logits)
+        chex.assert_tree_all_finite(value)
+
+    def test_rsa_forward_unchanged(self):
+        """Plain RSA envs keep link_resources-wide edge features (no regression)."""
+        config, params, state, model, pi, value = self._build_and_forward("rsa")
+        self.assertEqual(
+            state.graph.edges.shape,
+            (params.num_links, config.link_resources),
+        )
+        self.assertEqual(
+            model.actor.graph_net.edge_embedder.weight.shape[1],
+            config.link_resources,
+        )
+        self.assertIsInstance(pi, distrax.Categorical)
+        chex.assert_tree_all_finite(pi.logits)
+        chex.assert_tree_all_finite(value)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -624,7 +624,7 @@ def init_network(config: Box, key: chex.PRNGKey) -> eqx.Module:
                 actor_pooling=config.transformer_actor_pooling,
             )
         elif config.USE_GNN:
-            if "gn_model" in config.env_type.lower() and config.output_globals_size_actor > 0:
+            if "gn_model" in config.env_type.lower() and config.global_output_size_actor > 0:
                 global_output_size_actor = (
                     int((config.max_power - config.min_power) / config.step_power) + 1
                     if config.discrete_launch_power
@@ -637,8 +637,17 @@ def init_network(config: Box, key: chex.PRNGKey) -> eqx.Module:
                 if config.DISABLE_NODE_FEATURES
                 else config.num_spectral_features + 2  # 2 for source/dest indicators
             )
+            # Edge feature width must match graph.edges built by init_graph_tuple/
+            # update_graph_tuple: GN-model envs stack [normalized_snr, normalized_power]
+            # per slot (flattened to 2*link_resources at the GraphNet boundary); all other
+            # envs use link_slot_array/holding-time features (link_resources).
+            input_edge_feature_size = (
+                2 * config.link_resources
+                if "gn_model" in config.env_type.lower()
+                else config.link_resources
+            )
             network = ActorCriticGNN(
-                config.link_resources,
+                input_edge_feature_size,
                 input_node_feature_size,
                 1,  # Global input feature is just normalized requested datarate
                 activation=config.ACTIVATION,
@@ -1036,7 +1045,7 @@ def select_action(select_action_state, env, env_params, train_state, config):
             )
         inner_state = env_state.env_state.replace(launch_power_array=power_action)
         env_state = env_state.replace(env_state=inner_state)
-        if config.output_globals_size_actor == 0:
+        if config.global_output_size_actor == 0:
             path_index, _ = process_path_action(env_state.env_state, env_params, path_action)
             power_action, log_prob = power_action[path_index], log_prob[path_index]
         action = jnp.concatenate([path_action.reshape((1,)), power_action.reshape((1,))], axis=0)  # ty: ignore[unresolved-attribute]
@@ -1206,9 +1215,12 @@ def get_warmup_fn(warmup_state, env, params, train_state, config) -> Callable[[T
             elif (
                 "gn_model" in config.env_type.lower()
                 and config.launch_power_type != "rl"
+                and not config.USE_GNN
                 and not use_heuristic_warmup
                 and not use_random_warmup
             ):
+                # GNN policies emit plain path actions, which GN-model envs accept with
+                # non-RL launch power (process_action defaults the power element).
                 raise ValueError("Check that EVAL_HEURISTIC is set to True if using a heuristic")
             # STEP ENV
             obsv, _state, reward, terminal, truncated, info = env.step(


### PR DESCRIPTION
## Problem

Combining `--USE_GNN` with a GN-model environment (`rsa_gn_model` / `rmsa_gn_model`) crashes at trace time. Repro:

```bash
uv run python -m xlron.train.train --env_type=rsa_gn_model --topology_name=nsfnet_deeprmsa_directed \
  --link_resources=10 --k=4 --values_bw=100 --incremental_loading --slot_size=12.5 --guardband=0 \
  --ROLLOUT_LENGTH=10 --TOTAL_TIMESTEPS=20 --NUM_ENVS=1 --ENV_WARMUP_STEPS=0 --USE_GNN
```

This reproduces with `launch_power_type=fixed` (the default), so it is independent of the launch-power RL path. Four stacked defects, each unmasking the next:

1. **Config-key typo** — `init_network` (and the launch-power branch of `select_action`) read `config.output_globals_size_actor`; the flag is `global_output_size_actor`. `BoxKeyError` for every GNN + GN-model run.
2. **Edge-embedder width mismatch** (the headline bug) — GN-model envs build `graph.edges` as `stack([normalized_snr, normalized_power], axis=-1)` → `(E, link_resources, 2)`, flattened to **2×link_resources** features per edge at the `GraphNet` boundary. `init_network` hardcoded `link_resources`, producing a `dot_general` contracting-dimension mismatch (e.g. 10 vs 20).
3. **Actor output shape** — `ActorGNN` returned a `(path_dist, power_dist)` tuple for *any* `RSAGNModelEnvParams`, but with non-RL launch power `select_action`/`_loss_fn` expect a bare `Categorical` (`AttributeError: 'tuple' object has no attribute '_logits'`). It also never returned the tuple for `RMSAGNModelEnvParams`.
4. **Step-path assumptions** — the warmup guard raised for GN-model + non-RL power + RL policy, and `LogWrapper.step` unconditionally unpacked `action, power_action = action` (fails on the scalar path action a GNN policy emits), even though the raw env's `process_action` already handles 1-element actions.

## Changes

- `xlron/train/train_utils.py`
  - `init_network`: derive the GNN edge-embedder input width from the same source of truth the env uses to build `graph.edges` — `2 * link_resources` for `gn_model` env types, `link_resources` otherwise. (`DISABLE_NODE_FEATURES` and `aggregate_slots` are orthogonal: they affect node width / decoder output size, not edge input width.)
  - Fix the `output_globals_size_actor` → `global_output_size_actor` typo (both sites).
  - Narrow the warmup-guard `ValueError` to exclude `USE_GNN` runs.
- `xlron/models/gnn.py` — `ActorGNN` only returns the `(path_dist, power_dist)` tuple when `params.launch_power_type == "rl"` (a static `pytree_node=False` field, resolved at trace time), now also covering `RMSAGNModelEnvParams`.
- `xlron/environments/wrappers.py` — `LogWrapper.step` unpacks GN-model actions via `jnp.atleast_1d`, taking the power element only when present and logging `default_launch_power` otherwise (mirrors `process_action`).
- `xlron/models/models_test.py` (new) — construction + forward-pass regression tests: embedder width and `(E, S, 2)` edges on `rsa_gn_model`, bare path distribution under fixed power, `(path, power)` tuple under `launch_power_type=rl`, `rmsa_gn_model` forward, and the unchanged plain-RSA GNN path. The width test fails if the sizing fix is reverted.

## Behavior changes

**None for existing working configs.**
- Plain RSA/RMSA + GNN: identical construction and forward pass (verified e2e and by test).
- GNN + GN-model with any launch power type: previously crashed at trace time (nothing could have depended on the old behavior).
- `launch_power_type=rl` + GNN: still returns the `(path_dist, power_dist)` tuple; `rmsa_gn_model` + rl now also returns it (previously inconsistent and non-functional).
- `LogWrapper` `info["launch_power"]`: unchanged for 2-element actions; newly logs `default_launch_power` for bare path actions (a case that previously threw).

## Verification

- Repro command completes cleanly (exit 0, sane metrics: logged launch power 0.01995 W == configured 13 dBm/channel); same for `rmsa_gn_model`, `--mixed_precision`, and `ENV_WARMUP_STEPS=5`.
- No-regression e2e: same command with `--env_type=rsa` (no GN flags) passes.
- `uv run pytest xlron/models/models_test.py xlron/environments/gn_model/gn_model_test.py xlron/environments/env_funcs_test.py xlron/train/ppo_test.py xlron/environments/rsa/rsa_test.py xlron/environments/make_env_test.py xlron/dtype_config_test.py` — all green (591 passed, 125 skipped).

---
*Follow-up to the 13-PR review batch (user-requested task). Independent of the other open PRs (branched from main); expect small conflicts with #32/#35/#40/#43 in gnn.py/wrappers.py — whichever merges second needs a trivial rebase.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)