### PR TITLE
Fix VTrace + prioritized replay: compute advantages on the ordered rollout before resampling, with true bootstrap

### DIFF
--- a/docs/training.md
+++ b/docs/training.md
@@ -174,7 +174,7 @@ When enabled, `log(mu_old)` is subtracted from the log ratio before clipping, gi
 - **Interaction with `--IAM_DAMPING`:** recentering removes the implicit `mu_old` down-weighting of the actor gradient, so damping (`w *= clip(valid_mass / VALID_MASS_TARGET, 0, 1)`) becomes the only valid-mass-based down-weighting of congested states. Keep `IAM_DAMPING` on when using this flag. Damping and gating address valid-mass collapse (the off-policy gap), which is orthogonal to clip centring.
 - **Re-tune `--CLIP_EPS`:** because the gradient is now two-sided and no longer `mu_old`-scaled, the effective step size changes. A tight value such as `0.04` is usually too small once recentered; sweep `0.1`, `0.2`, `0.3` (and possibly the actor learning rate).
 - **Diagnostics:** with `--ENHANCED_LOGGING`, `diagnostics/recenter_ratio_mean`/`_std` report the recentered ratio (computed in both modes for comparison) and `diagnostics/neg_adv_clip_frac` reports the fraction of negative-advantage steps whose actor term is clipped — high in unit mode, low once recentered.
-- **Note:** the recentering applies only to the standard off-policy IAM branch. It is not applied to the VONE or launch-power branches. If VTrace-style clipping is enabled (`RHO_CLIP > 0` and `C_CLIP > 0`) the recentered ratio also feeds the importance correction in the advantage calculation; whether that ratio should be recentered too is left as an open question (VTrace is off by default).
+- **Note:** the recentering applies only to the standard off-policy IAM branch. It is not applied to the VONE or launch-power branches. If VTrace-style clipping is enabled (`RHO_CLIP > 0` and `C_CLIP > 0`) the recentered ratio also feeds the importance correction in the per-epoch VTrace advantage recomputation; whether that ratio should be recentered too is left as an open question (VTrace is off by default).
 - **Ablation outcome:** recentering alone is much worse than the non-recentered clip (it deletes the self-imitation filter and the `mu` weighting). Combined with `POSITIVE_ADV_ONLY` + `MU_WEIGHT_ACTOR` it matches the non-recentered configuration under bfloat16 but *loses and degrades late in training* under float32 — the explicit filter applies in every state, whereas the emergent one binds only in congested (`mu < 1 - eps`) states while the uncongested `mu ~ 1` lobe (most of the effective learning weight) trains two-sided. Treat these three flags as ablation instruments for studying the mechanism, not as a better-performing configuration.
 - **Diagnostics caveat:** `diagnostics/recenter_ratio_mean`/`_std` blow up (towards `exp(LOGR_CLIP)`) whenever a sample's stored valid mass underflows to ~0 — the `+1e-8` guard dominates — so ignore those columns on batches containing near-zero-`mu` states. Zero-valid-action states (masked sampling falls back to uniform) can also push the *unweighted* `ratio_max` above 1; they are gated out of the loss itself.
 
@@ -222,6 +222,8 @@ Initial average reward estimate and step size for the exponential moving average
 
 Priority exponent for prioritized sampling of the rollout buffer. `0.0` = uniform sampling (default), `1.0` = fully prioritized by absolute advantage. Samples with higher absolute advantage are replayed more often, with importance sampling corrections to maintain unbiased gradients.
 
+Prioritization is sample-level unless `USE_RNN` is set (RNN policies need whole trajectories, so entire environment rollouts are resampled instead). Sample-level prioritization composes safely with VTrace-style clipping (`RHO_CLIP`/`C_CLIP`): VTrace advantages and value targets are recomputed over the temporally-ordered rollout at the start of each update epoch, *before* resampling, so resampling cannot scramble the reverse-time scan.
+
 #### `--PRIO_BETA0`
 
 Initial importance sampling correction exponent. Annealed from `PRIO_BETA0` to `1.0` over training. `1.0` = full correction from the start (default). Lower values allow more biased but potentially faster early learning.
@@ -236,6 +238,8 @@ Clipping parameters for VTrace-style off-policy correction in the advantage calc
 - `C_CLIP`: Clips the ratio used in the GAE accumulation (`A_t = delta_t + gamma * lambda * c_t * A_{t+1}`)
 
 When both are `<= 0` (default), standard GAE is used without clipping. When `lambda=1` and both clips are set, this reduces to the VTrace algorithm. These are useful when doing multiple epochs of updates, as the policy changes between epochs making the data off-policy.
+
+When VTrace clipping is active, advantages and value targets are recomputed at the start of each update epoch: a fresh forward pass over the temporally-ordered rollout gives current-policy importance ratios, and the reverse-time scan runs with the true bootstrap value `V(s_{T+1})` captured after the rollout (values in the scan are the stored behaviour-policy values, as in standard VTrace). Ratios therefore track policy drift across `UPDATE_EPOCHS` but are frozen across the minibatches within an epoch. Because this happens before prioritized resampling or shuffling, VTrace is fully compatible with `PRIO_ALPHA > 0` and minibatch shuffling.
 
 ### `--include_no_op`
 

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -30,7 +30,10 @@ from xlron.train.train_utils import (
 )
 
 RunnerState = Tuple[TrainState, LogEnvState, Obsv, Array, Array]
-UpdateState = Tuple[TrainState, RSATransition | VONETransition, Array, Array, Array, Any, Array]
+# (train_state, traj_batch, adv, targets, last_val, rng_step, rng_epoch, priorities)
+UpdateState = Tuple[
+    TrainState, RSATransition | VONETransition, Array, Array, Array, Array, Any, Array
+]
 
 
 def compute_trajectory_priority_weights(advantages: Array, alpha: Array) -> Array:
@@ -69,8 +72,11 @@ def _sample_prioritized_batch(
     else:
         priority_probs = (priority_weights + 1e-6) / (jnp.sum(priority_weights) + 1e-6)
 
-        if not config.USE_RNN or (config.RHO_CLIP <= 0 or config.C_CLIP <= 0):
-            # If not using RNN or VTRACE-style clipping, we can prioritize individual samples
+        if not config.USE_RNN:
+            # Without an RNN we can prioritize individual samples: advantages (including
+            # VTrace advantages, which are recomputed over the ordered rollout in
+            # _recompute_vtrace_advantages before this function runs) are already attached
+            # per-sample, so resampling cannot scramble any temporal computation.
             sampled_indices = jax.random.choice(
                 sample_key, batch_size, shape=(batch_size,), p=priority_probs.reshape((batch_size,))
             )
@@ -118,14 +124,16 @@ def _sample_prioritized_batch(
             lambda x: x.reshape((batch_size,) + x.shape[2:]), batch_with_weights
         )
 
-    # Only shuffle the batch if we're not using an RNN-based policy and not using VTRACE-style clipping
-    if config.RHO_CLIP <= 0 or config.C_CLIP <= 0:
-        if not config.USE_RNN:
-            # Shuffle the batch
-            permutation = jax.random.permutation(shuffle_key, batch_size)
-            batch_with_weights = jax.tree.map(
-                lambda x: jnp.take(x, permutation, axis=0), batch_with_weights
-            )
+    # Only shuffle the batch if we're not using an RNN-based policy (which needs whole
+    # trajectories). Shuffling is safe under VTrace-style clipping because advantages and
+    # targets are recomputed over the temporally-ordered rollout *before* this function
+    # runs (see _recompute_vtrace_advantages) and ride along with each sample.
+    if not config.USE_RNN:
+        # Shuffle the batch
+        permutation = jax.random.permutation(shuffle_key, batch_size)
+        batch_with_weights = jax.tree.map(
+            lambda x: jnp.take(x, permutation, axis=0), batch_with_weights
+        )
 
     minibatches = jax.tree.map(
         lambda x: jnp.reshape(x, [config.NUM_MINIBATCHES, -1] + list(x.shape[1:])),
@@ -390,6 +398,7 @@ def _env_rollout_advantages(
         traj_batch: Trajectory batch from rollout
         adv: Computed advantages
         targets: Value targets
+        last_val: Bootstrap value V(s_{T+1}) of the post-rollout state (behaviour policy)
         priorities: Sample priorities for prioritized replay
     """
 
@@ -457,9 +466,12 @@ def _env_rollout_advantages(
         )
 
     # COMPUTE PRIORITIES AND ANNEALED BETA
+    # Sample-level priorities unless an RNN policy requires whole trajectories; VTrace-style
+    # clipping is compatible with sample-level prioritization because its advantages are
+    # recomputed on the ordered rollout before resampling (see _recompute_vtrace_advantages).
     priorities = (
         compute_sample_priority_weights(adv, train_state.prio_alpha)
-        if (not config.USE_RNN) or (config.RHO_CLIP <= 0 or config.C_CLIP <= 0)
+        if not config.USE_RNN
         else compute_trajectory_priority_weights(adv, train_state.prio_alpha)
     )
     # Anneal beta from initial value to 1.0 over course of training
@@ -475,31 +487,33 @@ def _env_rollout_advantages(
         annealed_beta,
     )
     runner_state = (train_state, env_state, last_obs, runner_state[3], rng_epoch)
-    return runner_state, traj_batch, adv, targets, priorities
+    return runner_state, traj_batch, adv, targets, last_val, priorities
 
 
-@eqx.filter_value_and_grad(has_aux=True)
-def _loss_fn(
-    model: eqx.Module,
-    train_state: TrainState,
-    batch_info: Tuple[RSATransition | VONETransition, Array, Array, Array],
+def _policy_log_prob_entropy(
+    pi: Any,
+    traj_batch: RSATransition | VONETransition,
     config: Box,
-) -> Tuple[
-    Array,
-    Tuple[Array, Array, Array, Array, Array, Array, Array, Array, LossDiagnostics],
-]:
-    """
-    Compute PPO loss (actor + value + entropy).
-    """
-    traj_batch, adv, targets, importance_weights = batch_info
-    # RERUN NETWORK - with Equinox, vmap the model directly.
-    # Mixed-precision compute: cast the (float32 master) weights to COMPUTE_DTYPE for the forward.
-    # This is inside the differentiated region, so gradients flow back to the float32 master.
-    model = cast_model_for_compute(model)
-    axes = (0, None) if config.USE_GNN or config.USE_TRANSFORMER else (0,)
-    pi, value = jax.vmap(model, in_axes=axes)(*traj_batch.obs)
+    targets: Array | None = None,
+) -> Tuple[Array, Array, bool]:
+    """Log-prob/entropy of the stored actions under the current policy output ``pi``.
 
-    # HANDLE DIFFERENT ACTION TYPES FOR OPTICAL NETWORKS
+    Shared by ``_loss_fn`` (per-minibatch PPO ratio) and ``_recompute_vtrace_advantages``
+    (per-epoch VTrace importance ratios over the ordered rollout). Handles the three
+    action-head layouts: VONE (three heads), launch-power RSA (path + power heads) and
+    the standard masked categorical.
+
+    Args:
+        pi: Batched policy output from vmapping the model over ``traj_batch.obs``
+        traj_batch: Batch of transitions (any leading batch shape, flattened to (B, ...))
+        config: Training config
+        targets: Optional value targets, only used for debug printing
+
+    Returns:
+        log_prob: Log probability of the stored actions under the current policy
+        entropy: Policy entropy (masked where applicable)
+        recenter_clip: Whether the standard off-policy IAM branch recenters the ratio
+    """
     recenter_clip = False  # only the standard off-policy IAM branch below recenters the clip
     if config.env_type.lower() == "vone":
         # VONE: source, path, destination actions. Slice the logits into per-head blocks
@@ -578,7 +592,8 @@ def _loss_fn(
         entropy = path_entropy + power_entropy
 
         if config.DEBUG:
-            jax.debug.print("targets {}", targets, ordered=config.ORDERED)
+            if targets is not None:
+                jax.debug.print("targets {}", targets, ordered=config.ORDERED)
             jax.debug.print("path_actions {}", path_actions, ordered=config.ORDERED)
             jax.debug.print("power_actions {}", power_actions, ordered=config.ORDERED)
             jax.debug.print("path_log_prob {}", path_log_prob, ordered=config.ORDERED)
@@ -603,41 +618,110 @@ def _loss_fn(
         recenter_clip = config.OFF_POLICY_IAM and config.get("IAM_RECENTER_CLIP", False)
         entropy = pi_masked.entropy()  # Always use the masked entropy, as we want to encourage exploration within the _valid_ action space
 
+    return log_prob, entropy, recenter_clip
+
+
+def _importance_ratio(
+    log_prob: Array,
+    traj_batch: RSATransition | VONETransition,
+    recenter_clip: bool,
+    config: Box,
+) -> Array:
+    """Clipped importance ratio of the current policy vs the stored behaviour log-probs."""
     log_ratio = log_prob - traj_batch.log_prob
     # Off-policy IAM ratio sits at mu_old (~0.5) not 1 at no-update; subtract log(mu_old)
-    # to recenter on pi_new/pi_old (~1) so the clip below is symmetric for both adv signs.
+    # to recenter on pi_new/pi_old (~1) so the downstream clipping is symmetric for both
+    # advantage signs.
     if recenter_clip:
         log_ratio = log_ratio - jnp.log(traj_batch.valid_mass.astype(jnp.float32) + 1e-8)
     log_ratio = jnp.clip(log_ratio, -config.LOGR_CLIP, config.LOGR_CLIP)
-    ratio = jnp.exp(log_ratio)
+    return jnp.exp(log_ratio)
 
-    # Recalculate the advantage now that we can clip based on the calculated importance ratio
-    # (NOTE: IAM_RECENTER_CLIP also recenters this VTrace importance ratio; whether it should
-    # be recentered here too is an open question - see PR note. Off by default: RHO_CLIP<=0.)
-    if config.RHO_CLIP > 0 and config.C_CLIP > 0:
-        minibatch_size = config.MINIBATCH_SIZE
-        assert config.ROLLOUT_LENGTH % config.NUM_MINIBATCHES == 0, (
-            "ROLLOUT_LENGTH must be integer mutliple of NUM_MINIBATCHES"
-        )
-        traj_batch, value, ratio = jax.tree.map(
-            lambda x: x.reshape(
-                (config.ROLLOUT_LENGTH // config.NUM_MINIBATCHES, config.NUM_ENVS) + x.shape[1:]
-            ),
-            (traj_batch, value, ratio),
-        )
-        adv, _, _ = jit_profiler.call(
-            config.PROFILE,
-            _calculate_puffer_advantage,
-            train_state,
+
+def _recompute_vtrace_advantages(
+    train_state: TrainState,
+    traj_batch: RSATransition | VONETransition,
+    last_val: Array,
+    config: Box,
+) -> Tuple[Array, Array]:
+    """Recompute VTrace advantages and value targets over the temporally-ordered rollout.
+
+    Runs a fresh forward pass with the current policy to get importance ratios, then the
+    reverse-time scan over the ordered (ROLLOUT_LENGTH, NUM_ENVS) rollout with the true
+    bootstrap value V(s_{T+1}) captured after the rollout. Called at the start of each
+    update epoch, *before* prioritized resampling / minibatch shuffling can permute
+    temporal order, mirroring how the standard-GAE path computes advantages once on
+    ordered data in _env_rollout_advantages.
+
+    Importance ratios are therefore refreshed once per epoch (tracking policy drift
+    across UPDATE_EPOCHS) and frozen across the minibatches within an epoch. The scan
+    uses the stored behaviour-policy values (traj_batch.value / last_val), consistent
+    with standard VTrace.
+
+    (NOTE: IAM_RECENTER_CLIP also recenters this VTrace importance ratio; whether it
+    should be recentered here too is an open question - see PR note. Off by default:
+    RHO_CLIP<=0.)
+    """
+    model = eqx.combine(train_state.model_params, train_state.model_static)
+    model = cast_model_for_compute(model)
+    # Flatten (ROLLOUT_LENGTH, NUM_ENVS, ...) -> (ROLLOUT_LENGTH * NUM_ENVS, ...) for the
+    # batched forward pass (same layout _sample_prioritized_batch flattens to later).
+    flat_batch = (
+        jax.tree.map(
+            lambda x: x.reshape((config.ROLLOUT_LENGTH * config.NUM_ENVS,) + x.shape[2:]),
             traj_batch,
-            value[-1],
-            ratio,
-            config,
         )
-        adv, traj_batch, value, ratio = jax.tree.map(
-            lambda x: x.reshape((minibatch_size,) + x.shape[2:]),
-            (adv, traj_batch, value, ratio),
-        )
+        if config.NUM_ENVS > 1
+        else traj_batch
+    )
+    axes = (0, None) if config.USE_GNN or config.USE_TRANSFORMER else (0,)
+    pi, _ = jax.vmap(model, in_axes=axes)(*flat_batch.obs)
+    log_prob, _, recenter_clip = _policy_log_prob_entropy(pi, flat_batch, config)
+    ratio = _importance_ratio(log_prob, flat_batch, recenter_clip, config)
+    # Restore time-major (ROLLOUT_LENGTH, NUM_ENVS) layout for the reverse-time scan
+    ratio = ratio.reshape(traj_batch.reward.shape)
+    adv, targets, _ = jit_profiler.call(
+        config.PROFILE,
+        _calculate_puffer_advantage,
+        train_state,
+        traj_batch,
+        last_val,
+        ratio,
+        config,
+    )
+    return adv, targets
+
+
+@eqx.filter_value_and_grad(has_aux=True)
+def _loss_fn(
+    model: eqx.Module,
+    train_state: TrainState,
+    batch_info: Tuple[RSATransition | VONETransition, Array, Array, Array],
+    config: Box,
+) -> Tuple[
+    Array,
+    Tuple[Array, Array, Array, Array, Array, Array, Array, Array, LossDiagnostics],
+]:
+    """
+    Compute PPO loss (actor + value + entropy).
+    """
+    traj_batch, adv, targets, importance_weights = batch_info
+    # RERUN NETWORK - with Equinox, vmap the model directly.
+    # Mixed-precision compute: cast the (float32 master) weights to COMPUTE_DTYPE for the forward.
+    # This is inside the differentiated region, so gradients flow back to the float32 master.
+    model = cast_model_for_compute(model)
+    axes = (0, None) if config.USE_GNN or config.USE_TRANSFORMER else (0,)
+    pi, value = jax.vmap(model, in_axes=axes)(*traj_batch.obs)
+
+    # HANDLE DIFFERENT ACTION TYPES FOR OPTICAL NETWORKS
+    log_prob, entropy, recenter_clip = _policy_log_prob_entropy(pi, traj_batch, config, targets)
+    ratio = _importance_ratio(log_prob, traj_batch, recenter_clip, config)
+
+    # NOTE: under VTrace-style clipping (RHO_CLIP > 0 and C_CLIP > 0) the advantages and
+    # value targets in batch_info were recomputed at the start of the epoch over the
+    # temporally-ordered rollout (see _recompute_vtrace_advantages), so no in-loss
+    # advantage recomputation happens here: the minibatch may be freely resampled or
+    # shuffled without breaking the reverse-time scan.
 
     # --- Per-step weight for actor + entropy losses ------------------------------
     mask_sum = jnp.sum(traj_batch.action_mask, axis=-1)
@@ -866,10 +950,25 @@ def _update_epoch(
     config: Box,
 ) -> Tuple[UpdateState, Tuple[Array, ...]]:
     """Single epoch of minibatch updates. Called via scan with closure wrapper."""
-    (train_state, traj_batch, adv, targets, rng_step, rng_epoch, priorities) = update_state
+    (train_state, traj_batch, adv, targets, last_val, rng_step, rng_epoch, priorities) = (
+        update_state
+    )
     rng_epoch, perm_key = jax.random.split(rng_epoch, 2)
 
-    batch = (traj_batch, adv, targets)
+    # VTrace-style clipping: recompute advantages/targets with fresh (current-policy)
+    # importance ratios over the temporally-ordered rollout and the true bootstrap value,
+    # BEFORE prioritized resampling / shuffling can permute temporal order. The GAE path
+    # (RHO_CLIP <= 0 or C_CLIP <= 0) keeps the rollout-time advantages unchanged. The
+    # epoch-local values are kept out of the scan carry (which keeps the rollout-time
+    # adv/targets) so the carry structure/dtypes stay stable across epochs.
+    if config.RHO_CLIP > 0 and config.C_CLIP > 0:
+        adv_epoch, targets_epoch = jit_profiler.call(
+            config.PROFILE, _recompute_vtrace_advantages, train_state, traj_batch, last_val, config
+        )
+    else:
+        adv_epoch, targets_epoch = adv, targets
+
+    batch = (traj_batch, adv_epoch, targets_epoch)
     minibatches, importance_weights_mb = jit_profiler.call(
         config.PROFILE,
         _sample_prioritized_batch,
@@ -892,6 +991,7 @@ def _update_epoch(
         traj_batch,
         adv,
         targets,
+        last_val,
         rng_step,
         rng_epoch,
         priorities,
@@ -912,7 +1012,7 @@ def _update_step(
     Composes _env_rollout and _update_epoch.
     """
 
-    runner_state, traj_batch, adv, targets, priorities = _env_rollout_advantages(
+    runner_state, traj_batch, adv, targets, last_val, priorities = _env_rollout_advantages(
         runner_state, env, env_params, config
     )
     (train_state, env_state, last_obs, rng_step, rng_epoch) = runner_state
@@ -922,6 +1022,7 @@ def _update_step(
         traj_batch,
         adv,
         targets,
+        last_val,
         rng_step,
         rng_epoch,
         priorities,
@@ -942,8 +1043,8 @@ def _update_step(
     )
 
     metric = traj_batch.info
-    rng_step = update_state[4]
-    rng_epoch = update_state[5]
+    rng_step = update_state[5]
+    rng_epoch = update_state[6]
     runner_state = (train_state, env_state, last_obs, rng_step, rng_epoch)
 
     loss_info = {

--- a/xlron/train/ppo_test.py
+++ b/xlron/train/ppo_test.py
@@ -19,9 +19,17 @@ import optax
 from absl.testing import absltest, parameterized
 from box import Box
 
+from xlron.environments.dataclasses import RSATransition
 from xlron.environments.make_env import make
 from xlron.models.mlp import ActorCriticMLP
-from xlron.train.ppo import _calculate_puffer_advantage, _env_step, _sample_prioritized_batch
+from xlron.train.ppo import (
+    _calculate_puffer_advantage,
+    _env_step,
+    _loss_fn,
+    _recompute_vtrace_advantages,
+    _sample_prioritized_batch,
+    compute_sample_priority_weights,
+)
 from xlron.train.train_utils import TrainState
 
 LOGR_CLIP = 10.0
@@ -240,6 +248,162 @@ class PrioritizedReplayWeightsTest(chex.TestCase):
             self._batch(config), priorities, jnp.array(0.4), jax.random.PRNGKey(0), config
         )
         chex.assert_trees_all_close(weights, jnp.ones_like(weights), atol=1e-6)
+
+
+class VTracePrioritizedReplayTest(chex.TestCase):
+    """Regression tests for VTrace + prioritized replay ordering.
+
+    VTrace advantages/targets must be computed over the temporally-ordered rollout with
+    the true bootstrap value V(s_{T+1}) BEFORE prioritized resampling / shuffling can
+    permute the batch. The old code re-ran the reverse-time scan inside ``_loss_fn`` over
+    (potentially resampled) minibatches — chaining randomly resampled transitions as if
+    consecutive whenever PRIO_ALPHA > 0 — and bootstrapped each chunk's last row on its
+    own value instead of V(s_{T+1}).
+    """
+
+    T, E, OBS_DIM, N_ACTIONS = 6, 3, 6, 5
+
+    def _config(self, **overrides):
+        base = dict(
+            env_type="rwa",
+            USE_GNN=False,
+            USE_TRANSFORMER=False,
+            USE_RNN=False,
+            OFF_POLICY_IAM=False,
+            LOGR_CLIP=10.0,
+            ROLLOUT_LENGTH=self.T,
+            NUM_ENVS=self.E,
+            NUM_MINIBATCHES=2,
+            MINIBATCH_SIZE=self.T * self.E // 2,
+            NUM_LEARNERS=1,
+            GAMMA=0.99,
+            GAE_LAMBDA=0.9,
+            REWARD_CENTERING=False,
+            RHO_CLIP=1.0,
+            C_CLIP=1.0,
+            PRIO_ALPHA=0.6,
+            PRIO_BETA0=0.4,
+            PROFILE=False,
+            DEBUG=False,
+            DEBUG_LOSS=False,
+            ENHANCED_LOGGING=False,
+            IAM_GATING=False,
+            IAM_DAMPING=False,
+            ADV_CLIP=10.0,
+            CLIP_EPS=0.2,
+            VF_COEF=0.5,
+            VALID_MASS_LOSS_COEF=0.0,
+        )
+        base.update(overrides)
+        return Box(base)
+
+    def _rollout(self, seed=0):
+        """Synthetic ordered (T, E) rollout whose stored log-probs come from the same
+        model, so the recomputed VTrace importance ratio is exactly 1 at no-update."""
+        t, e, obs_dim, n_actions = self.T, self.E, self.OBS_DIM, self.N_ACTIONS
+        kmodel, kobs, kact, krew, klast = jax.random.split(jax.random.PRNGKey(seed), 5)
+        model = ActorCriticMLP(n_actions, obs_dim, num_layers=1, num_units=16, key=kmodel)
+        train_state = TrainState.create(model, optax.adam(1e-3))
+        obs = jax.random.normal(kobs, (t, e, obs_dim))
+        pi, value = jax.vmap(model)(obs.reshape(t * e, obs_dim))
+        action = pi.sample(seed=kact)
+        # All-ones mask: the masked behaviour policy equals the unmasked policy
+        log_prob = pi.log_prob(action)
+        traj = RSATransition(
+            terminal=jnp.zeros((t, e), dtype=bool),
+            truncated=jnp.zeros((t, e), dtype=bool),
+            action=action.reshape(t, e),
+            value=value.reshape(t, e),
+            reward=jax.random.normal(krew, (t, e)),
+            log_prob=log_prob.reshape(t, e),
+            obs=(obs,),
+            # Unique per-sample id rides through resampling to identify each transition
+            info={"idx": jnp.arange(t * e, dtype=jnp.float32).reshape(t, e)},
+            action_mask=jnp.ones((t, e, n_actions)),
+            valid_mass=jnp.ones((t, e)),
+        )
+        last_val = jax.random.normal(klast, (e,))
+        return model, train_state, traj, last_val
+
+    def test_recompute_matches_ordered_reference_at_no_update(self):
+        _, train_state, traj, last_val = self._rollout()
+        config = self._config()
+        adv, targets = _recompute_vtrace_advantages(train_state, traj, last_val, config)
+        # At no-update the importance ratio is 1 everywhere, so the VTrace recompute must
+        # equal the plain advantage scan over the ordered rollout with unit ratios.
+        ref_adv, ref_targets, _ = _calculate_puffer_advantage(
+            train_state, traj, last_val, jnp.ones_like(traj.reward), config
+        )
+        self.assertEqual(adv.shape, (self.T, self.E))
+        chex.assert_trees_all_close(adv, ref_adv, atol=1e-5)
+        chex.assert_trees_all_close(targets, ref_targets, atol=1e-5)
+
+    def test_last_row_bootstraps_on_supplied_last_value(self):
+        _, train_state, traj, last_val = self._rollout()
+        config = self._config()
+        adv, _ = _recompute_vtrace_advantages(train_state, traj, last_val, config)
+        # Final-row advantage: delta_T = rho * (r_T + gamma * V(s_{T+1}) - V(s_T)), rho == 1
+        expected_last = traj.reward[-1] + config.GAMMA * last_val - traj.value[-1]
+        chex.assert_trees_all_close(adv[-1], expected_last, atol=1e-5)
+        # Regression: the old in-loss recompute bootstrapped each chunk on its own last
+        # value (delta_T = r_T + gamma * V(s_T) - V(s_T)) instead of V(s_{T+1}).
+        self_bootstrap = traj.reward[-1] + config.GAMMA * traj.value[-1] - traj.value[-1]
+        self.assertGreater(float(jnp.abs(adv[-1] - self_bootstrap).max()), 1e-4)
+
+    def test_advantages_ride_with_samples_through_prioritized_resampling(self):
+        """Order-invariance: with PRIO_ALPHA > 0 + VTrace clipping, every resampled sample
+        must carry exactly the advantage/target computed for it on the ordered rollout,
+        regardless of the resampling permutation (different RNG keys)."""
+        _, train_state, traj, last_val = self._rollout()
+        config = self._config()
+        adv, targets = _recompute_vtrace_advantages(train_state, traj, last_val, config)
+        priorities = compute_sample_priority_weights(adv, jnp.array(config.PRIO_ALPHA))
+        flat_adv, flat_targets = adv.reshape(-1), targets.reshape(-1)
+        for seed in (0, 1):
+            minibatches, _ = _sample_prioritized_batch(
+                (traj, adv, targets),
+                priorities,
+                jnp.array(config.PRIO_BETA0),
+                jax.random.PRNGKey(seed),
+                config,
+            )
+            mb_traj, mb_adv, mb_targets = minibatches
+            idx = mb_traj.info["idx"].reshape(-1).astype(jnp.int32)
+            # Resampling with replacement must permute (traj, adv, targets) consistently
+            chex.assert_trees_all_close(mb_adv.reshape(-1), flat_adv[idx], atol=1e-6)
+            chex.assert_trees_all_close(mb_targets.reshape(-1), flat_targets[idx], atol=1e-6)
+
+    def test_loss_uses_precomputed_advantages_not_in_loss_scan(self):
+        """With VTrace advantages precomputed on ordered data, ``_loss_fn`` must consume
+        them as-is: identical batch_info gives identical loss/grads whether the VTrace
+        clipping flags are on or off (the old code re-ran the scan in-loss when on).
+
+        The loss is evaluated with a *drifted* policy (different weights from the
+        behaviour model that produced the stored log-probs) so ratio != 1: at no-update
+        the actor term is -mean(normalized adv) == 0 for any advantages, which would make
+        this check vacuous.
+        """
+        _, train_state, traj, last_val = self._rollout()
+        drifted = ActorCriticMLP(
+            self.N_ACTIONS, self.OBS_DIM, num_layers=1, num_units=16, key=jax.random.PRNGKey(99)
+        )
+        n = self.T * self.E
+        config_vtrace = self._config(NUM_MINIBATCHES=1, MINIBATCH_SIZE=n)
+        config_gae = self._config(NUM_MINIBATCHES=1, MINIBATCH_SIZE=n, RHO_CLIP=0.0, C_CLIP=0.0)
+        adv, targets = _recompute_vtrace_advantages(train_state, traj, last_val, config_vtrace)
+        flat = jax.tree.map(lambda x: x.reshape((n,) + x.shape[2:]), (traj, adv, targets))
+        batch_info = (*flat, jnp.ones((n,)))
+        (loss_v, _), grads_v = _loss_fn(drifted, train_state, batch_info, config_vtrace)
+        (loss_g, _), grads_g = _loss_fn(drifted, train_state, batch_info, config_gae)
+        chex.assert_trees_all_close(loss_v, loss_g, atol=1e-6)
+        chex.assert_trees_all_close(grads_v, grads_g, atol=1e-6)
+        # The passed advantages must actually be consumed under the VTrace config: a
+        # non-affine perturbation (invariant neither to the loss's mean/std advantage
+        # normalization nor to the old in-loss recompute, which ignored passed adv
+        # entirely) must change the loss.
+        perturbed_info = (flat[0], flat[1] + flat[1] ** 2, flat[2], jnp.ones((n,)))
+        (loss_p, _), _ = _loss_fn(drifted, train_state, perturbed_info, config_vtrace)
+        self.assertGreater(abs(float(loss_p - loss_v)), 1e-6)
 
 
 class _Traj(NamedTuple):


### PR DESCRIPTION
## What

Fixes the verified `vtrace-per` finding: when `--PRIO_ALPHA > 0` is combined with VTrace-style clipping (`--RHO_CLIP > 0 --C_CLIP > 0`), per-sample prioritized resampling scrambled temporal order **before** the in-loss VTrace advantage scan, so the reverse-time scan chained randomly resampled `(t, env)` samples as if they were consecutive timesteps — producing meaningless advantages. Independently, the in-loss recompute bootstrapped every chunk's last row on its own value (`value[-1]`) instead of `V(s_{T+1})`, biasing `NUM_MINIBATCHES * NUM_ENVS` samples per rollout per epoch for **all** VTrace runs.

## How (chosen design: pre-resample computation, mirroring the GAE flow)

**`xlron/train/ppo.py`**

- **New `_recompute_vtrace_advantages`** — called at the start of each update epoch in `_update_epoch`, *before* `_sample_prioritized_batch`. It re-forwards the current policy over the temporally-ordered `(ROLLOUT_LENGTH, NUM_ENVS)` rollout to get importance ratios, then runs the reverse-time scan (`_calculate_puffer_advantage`) using the **stored behaviour-policy values** and the **true bootstrap `V(s_{T+1})`**. Advantages *and value targets* then ride along with each sample through resampling/shuffling, exactly like the standard-GAE path.
- **In-loss VTrace scan removed** from `_loss_fn` — the loss now always consumes the advantages/targets handed to it, so minibatches may be freely resampled and shuffled.
- **`last_val` threading** — `_env_rollout_advantages` returns the post-rollout bootstrap value, carried through `update_state` (the `UpdateState` alias is updated). The epoch-local recomputed adv/targets are deliberately kept out of the `lax.scan` carry so carry structure/dtypes stay stable under mixed precision.
- **PER conditions fixed** — `_sample_prioritized_batch`'s per-sample-vs-trajectory gate and `_env_rollout_advantages`' priority-type selection previously used the inverted condition `not USE_RNN or (RHO_CLIP <= 0 or C_CLIP <= 0)`; both now key on `USE_RNN` alone. The no-shuffle-under-VTrace guard is removed (shuffling is now safe). Side effect: `USE_RNN=True` + standard GAE now correctly gets trajectory-level prioritization (previously per-sample, which would have scrambled RNN sequences — latent, as no RNN model exists yet).
- **Shared helpers** — the current-policy log-prob/entropy branches (VONE / launch-power RSA / standard masked categorical) and the clipped importance ratio are extracted into `_policy_log_prob_entropy` and `_importance_ratio`, used by both `_loss_fn` and the epoch-level recompute so the two ratio computations cannot drift apart.

### Recompute-vs-freeze semantics (documented decision)

The old code refreshed VTrace ratios per minibatch inside the loss; an order-safe equivalent would require re-forwarding the full ordered rollout in every minibatch step. This PR refreshes ratios **once per update epoch** (tracking policy drift across `UPDATE_EPOCHS`, frozen across minibatches within an epoch), which is the closest order-safe match to the old intent and standard VTrace practice. The scan uses stored behaviour-policy values (as the old code did); only the ratios are fresh. With the defaults (`UPDATE_EPOCHS=1`, `NUM_MINIBATCHES=1`) semantics are identical to the old code apart from the bootstrap fix. The open question about whether `IAM_RECENTER_CLIP` should recenter the VTrace ratio is preserved as-is (comment + docs note).

## Tests (`xlron/train/ppo_test.py::VTracePrioritizedReplayTest`)

1. `test_recompute_matches_ordered_reference_at_no_update` — recompute equals the ordered unit-ratio advantage scan at no-update.
2. `test_last_row_bootstraps_on_supplied_last_value` — the final row uses the supplied `V(s_{T+1})`, and demonstrably *not* the old self-bootstrap value.
3. `test_advantages_ride_with_samples_through_prioritized_resampling` — **the required order-invariance regression**: with `PRIO_ALPHA>0` + `RHO_CLIP>0`, every resampled sample carries exactly the advantage/target computed for it on the ordered rollout, identical across different resampling permutations (unique per-sample ids in `info` track identity through resampling).
4. `test_loss_uses_precomputed_advantages_not_in_loss_scan` — identical `batch_info` gives identical loss/grads with VTrace flags on vs off, evaluated with a drifted policy (ratio != 1), plus a non-affine advantage-perturbation check guarding against vacuity (at no-update the normalized-advantage actor term is 0 for *any* advantages).

Verified against the pre-fix code (loaded from git): the old `_loss_fn` diverges between the two configs and ignores the passed advantages entirely, and the old per-sample PER branch scrambles temporal order under VTrace; the fixed code passes all four tests.

Also green: full `ppo_test.py` (17), `train_smoke_test.py` + `train_utils_test.py` (24, covers the launch-power loss branch), `vone_test.py::VoneRLSmokeTest` (2, covers the VONE loss branch), ruff + ty, and end-to-end CLI training smokes for PER+VTrace (`UPDATE_EPOCHS=2, NUM_MINIBATCHES=2`) and VTrace+`OFF_POLICY_IAM`.

**Docs**: `docs/training.md` — PRIO_ALPHA and RHO_CLIP/C_CLIP sections document the pre-resample recompute, its per-epoch refresh semantics, and PER compatibility.

## Behavior changes

- **PER + VTrace (previously wrong)**: `PRIO_ALPHA>0` with `RHO_CLIP>0`/`C_CLIP>0` now produces correct advantages; any prior results from this combination were computed from a scan over shuffled timesteps and should be discarded.
- **All VTrace runs**: last-transition bootstrap corrected from `V(s_T)` (self) to `V(s_{T+1})`.
- **VTrace with multiple epochs/minibatches**: advantage-scan ratios refresh per epoch (was per minibatch); value targets are now per-epoch VTrace targets (was rollout-time unit-ratio GAE targets). Defaults (1 epoch / 1 minibatch) unchanged apart from the bootstrap fix.
- **RNG streams**: VTrace minibatches are now shuffled, so seeded VTrace runs will not bit-match v1.4.0.
- **Latent**: `USE_RNN=True` + standard GAE now uses trajectory-level prioritization (no RNN model exists in the codebase yet).

The multidevice copies (`xlron/train/multidevice/ppo_multidevice.py`, `ppo_stoix.py`) implement neither VTrace nor PER and are unaffected.

---
*Follow-up batch (user-selected items from the July 2026 review). Each adversarially reviewed; full suite green per branch.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)