### PR TITLE
Fix load-sweep warmup bias: re-equilibrate network state at each swept load

### DIFF
--- a/docs/flags_reference.md
+++ b/docs/flags_reference.md
@@ -669,7 +669,9 @@ xlron.parameter_flags:
     (a number)
   --min_load: Minimum load for load sweep. When set (along with max_load and
     step_load), runs the experiment across a range of loads using a single
-    compilation.
+    compilation. Each swept load re-runs the ENV_WARMUP_STEPS warmup at its own
+    arrival rate and zeroes the metric counters, so per-load metrics reflect
+    that load's steady state.
     (a number)
   --min_node_resources: Minimum number of node resources
     (default: '1')

--- a/docs/heuristic_evaluation.md
+++ b/docs/heuristic_evaluation.md
@@ -118,7 +118,9 @@ The offered traffic load in Erlangs. This is the primary traffic parameter — i
 
 ### `--min_load` / `--max_load` / `--step_load`
 
-When all three are set, the script sweeps loads from `min_load` to `max_load` (inclusive) in steps of `step_load`. The environment is compiled once and reused across all loads without JIT recompilation, which is significantly faster than running separate processes per load. Each load produces its own JSONL summary line. `--load` should be set to the maximum load in the sweep range for initial compilation. Example:
+When all three are set, the script sweeps loads from `min_load` to `max_load` (inclusive) in steps of `step_load`. The environment is compiled once and reused across all loads without JIT recompilation, which is significantly faster than running separate processes per load. Each load produces its own JSONL summary line. `--load` should be set to the maximum load in the sweep range for initial compilation.
+
+Each swept load re-equilibrates before measurement: the warmup is re-run for `ENV_WARMUP_STEPS` at that load's arrival rate (a single extra compilation, reused across all loads) and the metric counters are zeroed afterwards, so each load's reported metrics reflect its own steady state rather than the network occupancy inherited from the initial `--load` warmup. This adds `ENV_WARMUP_STEPS` un-measured steps per swept load. Example:
 
 ```bash
 python -m xlron.train.train \

--- a/xlron/parameter_flags.py
+++ b/xlron/parameter_flags.py
@@ -434,7 +434,10 @@ flags.DEFINE_float(
     "min_load",
     None,
     "Minimum load for load sweep. When set (along with max_load and step_load), "
-    "runs the experiment across a range of loads using a single compilation.",
+    "runs the experiment across a range of loads using a single compilation. "
+    "Each swept load re-runs the ENV_WARMUP_STEPS warmup at its own arrival rate "
+    "and zeroes the metric counters, so per-load metrics reflect that load's "
+    "steady state.",
 )
 flags.DEFINE_float(
     "max_load",

--- a/xlron/train/train.py
+++ b/xlron/train/train.py
@@ -37,6 +37,7 @@ from xlron.parameter_flags import *  # noqa: F403,F401  # Ignore linter warnings
 from xlron.train.ppo import get_learner_fn
 from xlron.train.train_utils import (
     experiment_data_setup,
+    get_sweep_rewarm_fn,
     get_user_flags,
     load_model,
     log_actions,
@@ -638,6 +639,15 @@ def train(argv: list[str], config: Dict[str, Any] = {}) -> None:
     base_experiment_input = experiment_input
     mean_service_holding_time = float(env_params.mean_service_holding_time)
 
+    # For load sweeps, each load must re-equilibrate: the base state was warmed up at
+    # the original --load, so re-run the ENV_WARMUP_STEPS warmup at each swept load's
+    # arrival rate (compiled once, reused across loads) and zero the metric counters
+    # so per-load metrics exclude the re-equilibration transient.
+    sweep_rewarm = None
+    if len(loads) > 1 and config.ENV_WARMUP_STEPS:
+        sweep_rewarm = get_sweep_rewarm_fn(env, env_params, config)
+        sweep_rng = jax.random.PRNGKey(config.SEED + 2)
+
     for load_idx, load_val in enumerate(loads):
         load_val = float(load_val)
         if len(loads) > 1:
@@ -655,6 +665,14 @@ def train(argv: list[str], config: Dict[str, Any] = {}) -> None:
                 mean_service_holding_time,
                 config.NUM_LEARNERS,
             )
+            if sweep_rewarm is not None:
+                # Re-equilibrate the network at this load's arrival rate before
+                # measuring (fresh warmup key per load; counters zeroed after)
+                sweep_rng, load_warmup_key = jax.random.split(sweep_rng)
+                if config.NUM_LEARNERS > 1:
+                    load_warmup_key = jax.random.split(load_warmup_key, config.NUM_LEARNERS)
+                print(f"Re-running warmup ({config.ENV_WARMUP_STEPS} steps) at load {load_val:.1f}")
+                experiment_input = sweep_rewarm(experiment_input, load_warmup_key)
             # Update run/experiment names for this load
             run_name = create_run_name(config)
             experiment_name = config.EXPERIMENT_NAME if config.EXPERIMENT_NAME else run_name

--- a/xlron/train/train_smoke_test.py
+++ b/xlron/train/train_smoke_test.py
@@ -1,10 +1,12 @@
-"""End-to-end CPU training smoke tests for the RL launch-power path.
+"""End-to-end CPU training smoke tests for the train.py entry point.
 
-Regression cover for the launch_power_type="rl" training path, which rotted invisibly
-because nothing exercised the full train pipeline (init_network -> warmup/select_action
--> rollout -> _loss_fn) with a GN-model env. Each test runs the real entry point in a
-subprocess with a tiny config; a clean exit is the assertion. Marked slow (~20s each,
-dominated by XLA compilation): deselect with `pytest -m "not slow"`.
+Regression cover for (a) the launch_power_type="rl" training path, which rotted
+invisibly because nothing exercised the full train pipeline (init_network ->
+warmup/select_action -> rollout -> _loss_fn) with a GN-model env, and (b) the
+load-sweep path, which must re-run the warmup at each swept load. Each test runs
+the real entry point in a subprocess with a tiny config; a clean exit is the main
+assertion. Marked slow (~20s each, dominated by XLA compilation): deselect with
+`pytest -m "not slow"`.
 """
 
 import os
@@ -59,3 +61,51 @@ def test_launch_power_rl_training_smoke_continuous():
 def test_launch_power_rl_training_smoke_discrete():
     """MLP power-only policy with the discrete (Categorical) power head."""
     _run_train(["--discrete_launch_power"])
+
+
+LOAD_SWEEP_ARGS = [
+    "-m",
+    "xlron.train.train",
+    "--env_type=rsa",
+    "--topology_name=5node_directed",
+    "--link_resources=10",
+    "--k=2",
+    "--values_bw=1",
+    "--slot_size=1",
+    "--guardband=0",
+    "--continuous_operation",
+    "--EVAL_HEURISTIC",
+    "--path_heuristic=ksp_ff",
+    "--load=20",
+    "--min_load=10",
+    "--max_load=20",
+    "--step_load=10",
+    "--ENV_WARMUP_STEPS=10",
+    "--ROLLOUT_LENGTH=10",
+    "--TOTAL_TIMESTEPS=20",
+    "--NUM_ENVS=1",
+]
+
+
+@pytest.mark.slow
+def test_load_sweep_rewarms_each_load_smoke():
+    """A load sweep must re-run the warmup at every swept load (regression: the
+    sweep reused network state equilibrated at the original --load, biasing
+    per-load steady-state metrics)."""
+    env = dict(os.environ, JAX_PLATFORMS="cpu")
+    result = subprocess.run(
+        [sys.executable, *LOAD_SWEEP_ARGS],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        f"load sweep run failed (exit {result.returncode})\n"
+        f"--- stdout tail ---\n{result.stdout[-3000:]}\n"
+        f"--- stderr tail ---\n{result.stderr[-3000:]}"
+    )
+    # One re-warmup per swept load (2 loads: 10 and 20)
+    assert result.stdout.count("Re-running warmup") == 2, (
+        f"expected 2 re-warmups in stdout\n--- stdout tail ---\n{result.stdout[-3000:]}"
+    )

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -1340,6 +1340,49 @@ def get_warmup_fn(warmup_state, env, params, train_state, config) -> Callable[[T
     return warmup_fn
 
 
+def get_sweep_rewarm_fn(env, env_params, config) -> Callable[[Tuple, chex.PRNGKey], Tuple]:
+    """Build a jitted re-equilibration function for load sweeps.
+
+    A load sweep reuses the compiled experiment across loads, but the network state
+    (link occupancy, departure times) in the base experiment_input was warmed up at
+    the original ``--load``. Starting every swept load from that state biases per-load
+    steady-state metrics: low loads inherit an over-full network (blocking
+    overestimated), high loads an under-full one (underestimated). The returned
+    function re-runs the ``ENV_WARMUP_STEPS`` warmup at the state's (already updated)
+    arrival rate, then zeroes the warmup metric counters so each swept load's metrics
+    exclude the re-equilibration transient. Build it once outside the load loop:
+    ``arrival_rate`` is a dynamic state leaf, so the single compilation is reused
+    across all loads (preserving the sweep's compile-once behaviour).
+
+    Args:
+        env: Environment (same one the experiment was compiled with)
+        env_params: Environment parameters
+        config: Config Box (reads ENV_WARMUP_STEPS, NUM_ENVS, NUM_LEARNERS, ...)
+
+    Returns:
+        Jitted function (experiment_input, warmup_key) -> experiment_input, where
+        experiment_input is (runner_state, env_state, obsv, rng_step, rng_epoch).
+        With NUM_LEARNERS > 1 the function is vmapped over the leading learner axis
+        and warmup_key must be a batch of NUM_LEARNERS keys.
+    """
+
+    def rewarm_fn(experiment_input: Tuple, warmup_key: chex.PRNGKey) -> Tuple:
+        runner_state, env_state, obsv, rng_step, rng_epoch = experiment_input
+        warmup_key = (
+            jax.random.split(warmup_key, config.NUM_ENVS) if config.NUM_ENVS > 1 else warmup_key
+        )
+        warmup_state = (warmup_key, env_state, obsv)
+        warmup_fn = get_warmup_fn(warmup_state, env, env_params, runner_state, config)
+        warmup_fn = jax.vmap(warmup_fn) if config.NUM_ENVS > 1 else warmup_fn
+        env_state, obsv = warmup_fn(warmup_state)
+        env_state = reset_warmup_metric_counters(env_state)
+        return (runner_state, env_state, obsv, rng_step, rng_epoch)
+
+    if config.NUM_LEARNERS > 1:
+        rewarm_fn = jax.vmap(rewarm_fn)
+    return jax.jit(rewarm_fn)
+
+
 def steps_per_train_state_unit(config: Box) -> int:
     """Number of train_state.step increments per update loop.
 

--- a/xlron/train/train_utils_test.py
+++ b/xlron/train/train_utils_test.py
@@ -15,6 +15,7 @@ from xlron.models.mlp import ActorCriticMLP
 from xlron.train import ppo
 from xlron.train.train_utils import (
     diagnostics_metrics,
+    get_sweep_rewarm_fn,
     get_warmup_fn,
     loss_metrics,
     make_ent_schedule,
@@ -278,6 +279,122 @@ class ResetWarmupMetricCountersTest(absltest.TestCase):
         for old, new in zip(old_leaves, new_leaves):
             self.assertEqual(jnp.shape(old), jnp.shape(new))
             self.assertEqual(jnp.asarray(old).dtype, jnp.asarray(new).dtype)
+
+
+class SweepRewarmTest(absltest.TestCase):
+    """Regression tests for the load-sweep warmup bias: each swept load must
+    re-equilibrate the network at its own arrival rate (re-running the
+    ENV_WARMUP_STEPS warmup) and zero the metric counters, instead of measuring
+    from a state equilibrated at the original --load.
+    """
+
+    WARMUP_STEPS = 40
+
+    def _setup(self, num_envs=1):
+        settings = dict(
+            env_type="rsa",
+            topology_name="4node",
+            k=2,
+            link_resources=5,
+            values_bw=[1],
+            slot_size=1,
+            guardband=0,
+            load=100,
+            mean_service_holding_time=10,
+            continuous_operation=True,
+        )
+        env, params = make(settings)  # LogWrapper-wrapped (max_requests defaults to 1e4)
+        config = Box(
+            dict(
+                EVAL_HEURISTIC=True,
+                env_type="rsa",
+                path_heuristic="ksp_ff",
+                launch_power_type="fixed",
+                ENV_WARMUP_STEPS=self.WARMUP_STEPS,
+                NUM_ENVS=num_envs,
+                NUM_LEARNERS=1,
+                USE_GNN=False,
+                USE_TRANSFORMER=False,
+            )
+        )
+        reset_key = jax.random.PRNGKey(0)
+        if num_envs > 1:
+            reset_key = jax.random.split(reset_key, num_envs)
+            obs, state = jax.vmap(env.reset, in_axes=(0, None))(reset_key, params)
+        else:
+            obs, state = env.reset(reset_key, params)
+        return env, params, config, state, tuple([obs])
+
+    @staticmethod
+    def _experiment_input(state, obsv):
+        rng = jax.random.PRNGKey(1)
+        # runner_state=None: heuristic eval has no train state (as in select_action_eval)
+        return (None, state, obsv, rng, rng)
+
+    def test_rewarm_advances_requests_and_zeroes_counters(self):
+        env, params, config, state, obsv = self._setup()
+        rewarm = get_sweep_rewarm_fn(env, params, config)
+        total_before = int(state.env_state.total_requests)
+        out = rewarm(self._experiment_input(state, obsv), jax.random.PRNGKey(2))
+        _, new_state, _, _, _ = out
+        # Warmup actually ran at the new load...
+        self.assertEqual(int(new_state.env_state.total_requests), total_before + self.WARMUP_STEPS)
+        # ...and its transient is excluded from the per-load metrics
+        for field in ("lengths", "cum_returns", "accepted_services"):
+            self.assertEqual(float(getattr(new_state, field)), 0.0, f"LogEnvState.{field}")
+        for field in ("accepted_services", "accepted_bitrate", "total_bitrate"):
+            self.assertEqual(float(getattr(new_state.env_state, field)), 0.0, f"env.{field}")
+
+    def test_rewarm_reequilibrates_occupancy_to_new_load(self):
+        """Sweeping from a high to a much lower load must not inherit the high-load
+        occupancy: after the re-warmup the network reflects the new steady state."""
+        env, params, config, state, obsv = self._setup()
+        rewarm = get_sweep_rewarm_fn(env, params, config)
+        # Equilibrate at the original (high) load: arrival_rate = 100/10 = 10
+        _, high_state, high_obsv, rng_step, rng_epoch = rewarm(
+            self._experiment_input(state, obsv), jax.random.PRNGKey(2)
+        )
+        occupied_high = int(jnp.count_nonzero(high_state.env_state.link_slot_array))
+        self.assertGreater(occupied_high, 0)
+
+        # Sweep to a near-zero load: only arrival_rate changes, exactly as
+        # train.py:_update_experiment_input_load does
+        inner = high_state.env_state.replace(
+            arrival_rate=jnp.full_like(high_state.env_state.arrival_rate, 0.01)
+        )
+        low_input = (None, high_state.replace(env_state=inner), high_obsv, rng_step, rng_epoch)
+        _, low_state, _, _, _ = rewarm(low_input, jax.random.PRNGKey(3))
+        occupied_low = int(jnp.count_nonzero(low_state.env_state.link_slot_array))
+        # Inter-arrival time (100) >> holding time (10): the high-load occupancy
+        # must have drained during the re-warmup
+        self.assertLess(occupied_low, occupied_high)
+
+    def test_rewarm_preserves_structure_for_compiled_experiment(self):
+        """The rewarmed experiment_input feeds the already-compiled experiment fn,
+        so every leaf must keep its shape and dtype."""
+        env, params, config, state, obsv = self._setup()
+        rewarm = get_sweep_rewarm_fn(env, params, config)
+        experiment_input = self._experiment_input(state, obsv)
+        out = rewarm(experiment_input, jax.random.PRNGKey(2))
+        old_leaves = jax.tree_util.tree_leaves(experiment_input)
+        new_leaves = jax.tree_util.tree_leaves(out)
+        self.assertEqual(len(old_leaves), len(new_leaves))
+        for old, new in zip(old_leaves, new_leaves):
+            self.assertEqual(jnp.shape(old), jnp.shape(new))
+            self.assertEqual(jnp.asarray(old).dtype, jnp.asarray(new).dtype)
+
+    def test_rewarm_vmapped_envs(self):
+        """NUM_ENVS > 1: the warmup is vmapped and each env gets its own key."""
+        num_envs = 2
+        env, params, config, state, obsv = self._setup(num_envs=num_envs)
+        rewarm = get_sweep_rewarm_fn(env, params, config)
+        total_before = jnp.asarray(state.env_state.total_requests)
+        out = rewarm(self._experiment_input(state, obsv), jax.random.PRNGKey(2))
+        _, new_state, _, _, _ = out
+        self.assertTrue(
+            bool(jnp.all(new_state.env_state.total_requests == total_before + self.WARMUP_STEPS))
+        )
+        self.assertTrue(bool(jnp.all(new_state.lengths == 0)))
 
 
 class LossInfoMetricRegistrationTest(absltest.TestCase):


### PR DESCRIPTION
# Fix load-sweep warmup bias: re-equilibrate network state at each swept load

## What / Why

The load sweep (`--min_load`/`--max_load`/`--step_load`) captured `base_experiment_input` once after `experiment_data_setup` — whose `ENV_WARMUP_STEPS` warmup ran at the **original** `--load` — and for each swept load only overwrote `arrival_rate`/`mean_service_holding_time` via `_update_experiment_input_load` (`xlron/train/train.py`). Every swept load therefore started measuring from the wrong steady state: link occupancy and departure times were equilibrated at the compile-time load, so low loads inherited an over-full network (blocking overestimated) and high loads an under-full one (underestimated). This defeated the purpose of `ENV_WARMUP_STEPS` for sweep measurements — a primary heuristic-evaluation use case (`docs/heuristic_evaluation.md` recommends exactly this sweep setup).

### Changes

- **`xlron/train/train_utils.py`** — new `get_sweep_rewarm_fn(env, env_params, config)`: returns a jitted function `(experiment_input, warmup_key) -> experiment_input` that re-runs the `ENV_WARMUP_STEPS` warmup (via the existing `get_warmup_fn`) at the state's already-updated arrival rate, then zeroes the warmup metric counters with the existing `reset_warmup_metric_counters` (v1.3.0 warmup-contamination fix) so per-load metrics exclude the re-equilibration transient. `total_requests` is deliberately preserved (drives episode truncation). Vmapped over `NUM_ENVS`, and over the learner axis when `NUM_LEARNERS > 1`. Since `arrival_rate` is a dynamic state leaf, the function is **built and compiled once** outside the load loop and reused for every load — the sweep's compile-once selling point is preserved (one extra compilation total, not one per load).
- **`xlron/train/train.py`** — builds the rewarm fn when `len(loads) > 1 and config.ENV_WARMUP_STEPS`, and calls it immediately after `_update_experiment_input_load` for **every** swept load (including the first: the base warmup ran at `--load`, which need not equal `min_load`). Each load gets a fresh warmup key split from `PRNGKey(SEED + 2)` (never reusing the setup keys); with `NUM_LEARNERS > 1` the key is split per learner. Prints `Re-running warmup (N steps) at load X` per load.
- **Docs** — `docs/heuristic_evaluation.md` sweep section documents the per-load re-warmup and the added un-measured steps; `--min_load` flag help updated in `xlron/parameter_flags.py`; `docs/flags_reference.md` regenerated.

The rewarmed `experiment_input` keeps every leaf's shape and dtype (warmup goes through the same `env.step`/obs-rebuild path as `experiment_data_setup`, and `reset_warmup_metric_counters` uses `zeros_like`), so it feeds the already-compiled experiment fn without retrace — verified by test.

Out of scope: the bounds scripts (`xlron/bounds/cutsets_bounds.py`, `reconfigurable_routing_bounds.py`) have their own independent per-load simulation loops and do not share this mechanism, so their docs sections are untouched.

## Tests added

- `xlron/train/train_utils_test.py::SweepRewarmTest` (fail before fix / pin new behavior):
  - `test_rewarm_advances_requests_and_zeroes_counters` — warmup actually runs (`total_requests` += `ENV_WARMUP_STEPS`) and LogWrapper + inner metric counters are zeroed at the load boundary.
  - `test_rewarm_reequilibrates_occupancy_to_new_load` — the bias scenario: equilibrate at load 100, sweep to near-zero arrival rate exactly as `_update_experiment_input_load` does, and assert the inherited `link_slot_array` occupancy drains during the re-warmup.
  - `test_rewarm_preserves_structure_for_compiled_experiment` — every leaf keeps shape and dtype (compiled-fn / dtype-tier safety).
  - `test_rewarm_vmapped_envs` — `NUM_ENVS=2` path.
- `xlron/train/train_smoke_test.py::test_load_sweep_rewarms_each_load_smoke` — end-to-end subprocess sweep over two loads (rsa, `5node_directed`, `ksp_ff`) asserting clean exit and exactly one re-warmup per swept load.

`JAX_PLATFORMS=cpu uv run pytest xlron/train/train_utils_test.py xlron/train/train_smoke_test.py -q` → 29 passed. Pre-commit (ruff, ruff-format, ty) passes.

## Behavior changes

- **Sweep runs take longer**: each swept load runs an extra `ENV_WARMUP_STEPS` warmup (e.g. +3000 steps/env per load with the documented settings).
- **Per-load sweep metrics change** (previously biased): each load is measured from its own re-equilibrated steady state with metric counters zeroed at the load boundary. Expect lower reported blocking at low loads and higher at high loads relative to old sweep outputs.
- Swept-load trajectories also consume fresh PRNG randomness (warmup keys from `PRNGKey(SEED + 2)`), so results differ from previous runs beyond the bias correction itself.
- Single-load runs and sweeps with `ENV_WARMUP_STEPS=0` are unchanged. New stdout line per swept load: `Re-running warmup (N steps) at load X`.

---
*Follow-up batch (user-selected items from the July 2026 review). Each adversarially reviewed; full suite green per branch.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)