### PR TITLE
Add blocking-cause breakdown (spectrum vs SNR vs power) for GN-model envs

### DIFF
--- a/docs/gn_model.md
+++ b/docs/gn_model.md
@@ -432,6 +432,32 @@ The `rmsa_gn_model` environment tracks:
 
 It does not compute Shannon throughput (unlike `rsa_gn_model`).
 
+### Blocking-Cause Breakdown
+
+GN-model environments expose per-episode counters that record *why* requests were blocked,
+which distinguishes spectrum-limited from physics-limited operation (the key diagnostic for
+launch-power/margin tuning and for interpreting RL-vs-heuristic gaps):
+
+- `blocked_spectrum`: blocked because no free contiguous spectrum was available (the RSA validity check failed)
+- `blocked_snr`: blocked because the SNR feasibility check failed (the new lightpath or an existing lightpath would fall below its modulation format's required SNR)
+- `blocked_power`: blocked because the total power on a fibre would exceed `max_power_per_fibre`
+
+A blocked request is attributed to exactly one cause, with priority spectrum > SNR > power
+(a spectrum collision corrupts the tentatively-placed GN state, so SNR/power failures on such a
+step would be spurious). The counters are therefore mutually exclusive and sum to the total
+number of blocked requests. Like `accepted_services`, they accumulate within an episode and
+reset with it.
+
+For `rmsa_gn_model`, all three causes are counted from the step-time acceptance checks. For
+`rsa_gn_model`, SNR feasibility is enforced in the action mask rather than the step-time
+acceptance check, so all blocks are attributed to `blocked_spectrum` and the other two
+counters stay zero.
+
+The counters are reported in the step `info` dict (and thus to W&B and the episode CSV),
+along with derived per-request rates `spectrum_blocking_probability`,
+`snr_blocking_probability` and `power_blocking_probability`, which sum to
+`service_blocking_probability`. Non-GN environments do not report these metrics.
+
 
 ---
 

--- a/xlron/environments/dataclasses.py
+++ b/xlron/environments/dataclasses.py
@@ -182,6 +182,9 @@ class LogEnvState:
         total_bitrate (chex.Scalar): Total bitrate requested
         utilisation (chex.Scalar): Network utilisation
         fragmentation (chex.Scalar): Mean external spectrum fragmentation across links
+        blocked_spectrum (chex.Scalar): Requests blocked by spectrum contention (GN-model envs, else 0)
+        blocked_snr (chex.Scalar): Requests blocked by insufficient SNR (GN-model envs, else 0)
+        blocked_power (chex.Scalar): Requests blocked by the per-fibre power budget (GN-model envs, else 0)
         terminal (chex.Scalar): Terminal flag (true termination condition met)
         truncated (chex.Scalar): Truncated flag (max steps reached)
     """
@@ -195,6 +198,9 @@ class LogEnvState:
     total_bitrate: Array
     utilisation: Array
     fragmentation: Array
+    blocked_spectrum: Array
+    blocked_snr: Array
+    blocked_power: Array
     terminal: Array
     truncated: Array
 
@@ -370,8 +376,16 @@ class GNModelEnvParams(RSAEnvParams):
 
 @struct.dataclass
 class GNModelEnvState(RSAEnvState):
-    """Dataclass to hold environment state for RSA with GN model."""
+    """Dataclass to hold environment state for RSA with GN model.
 
+    The blocked_* fields count blocked requests by cause (cumulative within an episode,
+    like accepted_services). Causes are attributed with spectrum > SNR > power priority,
+    so the counters are mutually exclusive and sum to the total number of blocked requests.
+    """
+
+    blocked_spectrum: Array  # Count of requests blocked by spectrum contention
+    blocked_snr: Array  # Count of requests blocked by insufficient SNR
+    blocked_power: Array  # Count of requests blocked by the per-fibre power budget
     link_snr_array: Array  # Available SNR on each link
     channel_centre_bw_array: Array  # Channel centre bandwidth for each active connection
     path_index_array: (

--- a/xlron/environments/env_funcs.py
+++ b/xlron/environments/env_funcs.py
@@ -4372,6 +4372,35 @@ def set_band_gaps(link_slot_array: Array, params: RSAGNModelEnvParams, val: int)
 
 
 @partial(jax.jit, static_argnums=(2,))
+def check_action_rmsa_gn_model_components(
+    state: GNModelEnvState, action_info: ActionInfo, params: GNModelEnvParams
+) -> tuple:
+    """Compute the individual acceptance checks for the RMSA GN model.
+
+    The three checks correspond to the possible blocking causes:
+    spectrum contention, insufficient SNR, and per-fibre power budget.
+    step_env uses the components to count blocking causes without recomputing them;
+    check_action_rmsa_gn_model aggregates them into the overall validity check.
+
+    Args:
+        state (EnvState): Environment state
+        action_info (ActionInfo): Action info
+        params (EnvParams): Environment parameters
+    Returns:
+        tuple: (rsa_check, snr_sufficient_check, power_check) - each truthy if the
+        corresponding check failed (action invalid)
+    """
+    snr_sufficient_check = check_snr_sufficient(state, params)
+    rsa_check = check_action_rsa(state, action_info, params)
+    # Check total power per link doesn't exceed max_power_per_fibre
+    total_power = compute_total_power_per_link(
+        state.channel_power_array, state.path_index_array, state.channel_centre_freq_array
+    )
+    power_check = jnp.any(total_power > params.max_power_per_fibre)
+    return rsa_check, snr_sufficient_check, power_check
+
+
+@partial(jax.jit, static_argnums=(2,))
 def check_action_rmsa_gn_model(
     state: GNModelEnvState, action_info: ActionInfo, params: GNModelEnvParams
 ) -> bool:
@@ -4383,15 +4412,9 @@ def check_action_rmsa_gn_model(
     Returns:
         bool: True if action is invalid, False if action is valid
     """
-    # Check if action is valid
-    # TODO - log failure reasons in info
-    snr_sufficient_check = check_snr_sufficient(state, params)
-    rsa_check = check_action_rsa(state, action_info, params)
-    # Check total power per link doesn't exceed max_power_per_fibre
-    total_power = compute_total_power_per_link(
-        state.channel_power_array, state.path_index_array, state.channel_centre_freq_array
+    rsa_check, snr_sufficient_check, power_check = check_action_rmsa_gn_model_components(
+        state, action_info, params
     )
-    power_check = jnp.any(total_power > params.max_power_per_fibre)
     return jnp.any(
         jnp.stack(
             (

--- a/xlron/environments/gn_model/gn_model_test.py
+++ b/xlron/environments/gn_model/gn_model_test.py
@@ -2211,6 +2211,200 @@ class GetPathsObsGNModelVmapTest(chex.TestCase):
             np.testing.assert_allclose(gn_stats, expected, rtol=1e-4, atol=1e-6)
 
 
+class BlockingCauseCountersTest(chex.TestCase):
+    """Blocking-cause breakdown (spectrum vs SNR vs power) counters in GN-model envs.
+
+    Each test forces exactly one acceptance check to fail and asserts that only the
+    corresponding counter increments. Causes are attributed with spectrum > SNR > power
+    priority, so the counters are mutually exclusive.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = rmsa_gn_model_test_setup()
+
+    def _masked_state_and_action(self, state, params, env=None):
+        """Compute the action mask and return (masked state, first valid action)."""
+        env = env or self.env
+        mask, _, mod_format_mask = env.action_mask(state, params)
+        state = state.replace(link_slot_mask=mask, mod_format_mask=mod_format_mask)
+        path_action = jnp.argmax(mask > 0)
+        action = jnp.concatenate([path_action.reshape((1,)), jnp.array([0]).reshape((1,))], axis=0)
+        return state, action
+
+    def _assert_counters(self, state, spectrum, snr, power):
+        self.assertEqual(int(state.blocked_spectrum), spectrum)
+        self.assertEqual(int(state.blocked_snr), snr)
+        self.assertEqual(int(state.blocked_power), power)
+
+    def test_counters_zero_at_reset(self):
+        self._assert_counters(self.state, 0, 0, 0)
+
+    def test_accepted_request_increments_no_counters(self):
+        state, action = self._masked_state_and_action(self.state, self.params)
+        _, new_state, reward, _, _, info = self.env.step(self.key, state, action, self.params)
+        self.assertEqual(int(new_state.accepted_services), 1)
+        self._assert_counters(new_state, 0, 0, 0)
+        self.assertEqual(int(info["_blocked_spectrum"]), 0)
+        self.assertEqual(int(info["_blocked_snr"]), 0)
+        self.assertEqual(int(info["_blocked_power"]), 0)
+
+    def test_spectrum_blocked_increments_spectrum_counter_only(self):
+        # Occupy every slot on every link so any placement collides
+        state = self.state.replace(link_slot_array=jnp.ones_like(self.state.link_slot_array))
+        action = jnp.array([0, 0])
+        _, new_state, reward, _, _, info = self.env.step(self.key, state, action, self.params)
+        self.assertEqual(int(new_state.accepted_services), 0)
+        self.assertLess(float(reward), 0)
+        # SNR/power must not be (mis)attributed even if the collision corrupts the
+        # tentative GN state - spectrum takes priority
+        self._assert_counters(new_state, 1, 0, 0)
+        self.assertEqual(int(info["_blocked_spectrum"]), 1)
+
+    def test_snr_blocked_increments_snr_counter_only(self):
+        # Compute a valid action on the clean network first, then fabricate a degraded
+        # existing connection at (link 0, last slot): occupied bandwidth, highest-order
+        # modulation format (high required SNR), negligible launch power. The SNR
+        # sufficiency check re-evaluates all active connections after the tentative
+        # placement, so this connection fails it while spectrum and power checks pass.
+        state, action = self._masked_state_and_action(self.state, self.params)
+        params = self.params
+        paths = params.path_link_array.val
+        if params.pack_path_bits:
+            paths = jnp.unpackbits(paths, axis=1)[:, : params.num_links]
+        path_through_link0 = int(np.argmax(np.asarray(paths)[:, 0] > 0))
+        num_mods = params.modulations_array.val.shape[0]
+        slot = params.link_resources - 1
+        state = state.replace(
+            channel_centre_bw_array=state.channel_centre_bw_array.at[0, slot].set(params.slot_size),
+            channel_power_array=state.channel_power_array.at[0, slot].set(1e-12),
+            channel_centre_freq_array=state.channel_centre_freq_array.at[0, slot].set(
+                params.slot_centre_freq_array.val[slot]
+            ),
+            path_index_array=state.path_index_array.at[0, slot].set(path_through_link0),
+            modulation_format_index_array=state.modulation_format_index_array.at[0, slot].set(
+                num_mods - 1
+            ),
+        )
+        _, new_state, reward, _, _, info = self.env.step(self.key, state, action, self.params)
+        self.assertEqual(int(new_state.accepted_services), 0)
+        self.assertLess(float(reward), 0)
+        self._assert_counters(new_state, 0, 1, 0)
+        self.assertEqual(int(info["_blocked_snr"]), 1)
+
+    def test_power_blocked_increments_power_counter_only(self):
+        # Same env as rmsa_gn_model_test_setup but with a per-fibre power budget far
+        # below the (explicitly pinned) per-channel launch power, so any placement
+        # trips the power check. SNR passes (launch power and request are unchanged
+        # from the accepted-request test) and spectrum passes (empty network).
+        key, env, obs, state, params = _gn_cached_setup(
+            "rmsa_gn_model_tiny_power",
+            dict(
+                k=4,
+                topology_name="nsfnet_deeprmsa_directed",
+                link_resources=10,
+                max_requests=100,
+                values_bw=[100],
+                incremental_loading=True,
+                env_type="rmsa_gn_model",
+                slot_size=12.5,
+                guardband=0,
+                mod_format_correction=False,
+                max_power_per_fibre=-90.0,  # dBm -> 1e-12 W
+                power_per_channel=0.0,  # dBm -> 1 mW, same as the default setup
+                coherent=False,
+                include_no_op=False,
+            ),
+            seed=3,
+        )
+        # The power budget is also enforced in the action mask, so compute the mask
+        # with the permissive default params (identical env/state otherwise)
+        state, action = self._masked_state_and_action(state, self.params, env=env)
+        _, new_state, reward, _, _, info = env.step(key, state, action, params)
+        self.assertEqual(int(new_state.accepted_services), 0)
+        self.assertLess(float(reward), 0)
+        self._assert_counters(new_state, 0, 0, 1)
+        self.assertEqual(int(info["_blocked_power"]), 1)
+
+    def test_check_action_rmsa_gn_model_matches_components(self):
+        # The aggregate check must remain jnp.any over the same component stack
+        state, action = self._masked_state_and_action(self.state, self.params)
+        action_info = self.env.process_action(state, action, self.params)
+        components = check_action_rmsa_gn_model_components(state, action_info, self.params)
+        aggregate = check_action_rmsa_gn_model(state, action_info, self.params)
+        self.assertEqual(
+            bool(aggregate), bool(jnp.any(jnp.stack([jnp.asarray(c) for c in components])))
+        )
+
+    def test_log_wrapper_reports_blocking_cause_counters(self):
+        key = jax.random.PRNGKey(3)
+        if "rmsa_gn_model_logwrapper" not in _gn_cache:
+            env, params = make(
+                dict(
+                    k=4,
+                    topology_name="nsfnet_deeprmsa_directed",
+                    link_resources=10,
+                    max_requests=100,
+                    values_bw=[100],
+                    incremental_loading=True,
+                    env_type="rmsa_gn_model",
+                    slot_size=12.5,
+                    guardband=0,
+                    mod_format_correction=False,
+                    max_power_per_fibre=10.0,
+                    coherent=False,
+                    include_no_op=False,
+                )
+            )
+            _gn_cache["rmsa_gn_model_logwrapper"] = (env, params)
+        env, params = _gn_cache["rmsa_gn_model_logwrapper"]
+        obs, log_state = env.reset(key, params)
+        # Force a spectrum block by filling the spectrum
+        log_state = log_state.replace(
+            env_state=log_state.env_state.replace(
+                link_slot_array=jnp.ones_like(log_state.env_state.link_slot_array)
+            )
+        )
+        action = jnp.array([0, 0])
+        obs, log_state, reward, terminal, truncated, info = env.step(key, log_state, action, params)
+        # Raw stashes are popped; public keys and LogEnvState fields are reported
+        self.assertNotIn("_blocked_spectrum", info)
+        self.assertEqual(int(info["blocked_spectrum"]), 1)
+        self.assertEqual(int(info["blocked_snr"]), 0)
+        self.assertEqual(int(info["blocked_power"]), 0)
+        self.assertEqual(int(log_state.blocked_spectrum), 1)
+
+    def test_non_gn_env_does_not_report_blocking_causes(self):
+        key = jax.random.PRNGKey(0)
+        if "rwa_4node_logwrapper" not in _gn_cache:
+            env, params = make(
+                dict(
+                    load=100,
+                    k=2,
+                    topology_name="4node",
+                    link_resources=4,
+                    max_requests=10,
+                    mean_service_holding_time=10,
+                    env_type="rwa",
+                    values_bw=[1],
+                    slot_size=1,
+                    guardband=0,
+                )
+            )
+            _gn_cache["rwa_4node_logwrapper"] = (env, params)
+        env, params = _gn_cache["rwa_4node_logwrapper"]
+        obs, log_state = env.reset(key, params)
+        obs, log_state, reward, terminal, truncated, info = env.step(
+            key, log_state, jnp.array(0), params
+        )
+        self.assertNotIn("blocked_spectrum", info)
+        self.assertNotIn("blocked_snr", info)
+        self.assertNotIn("blocked_power", info)
+        # Non-GN env states carry no counters; the LogEnvState defaults stay zero
+        self.assertFalse(hasattr(log_state.env_state, "blocked_spectrum"))
+        self.assertEqual(int(log_state.blocked_spectrum), 0)
+
+
 if __name__ == "__main__":
     jax.config.update("jax_numpy_rank_promotion", "raise")
     absltest.main()

--- a/xlron/environments/gn_model/rmsa_gn_model.py
+++ b/xlron/environments/gn_model/rmsa_gn_model.py
@@ -81,6 +81,11 @@ class RMSAGNModelEnv(RSAEnv):
             accepted_services=0,
             accepted_bitrate=0.0,
             total_bitrate=0.0,
+            # Blocking-cause counters: carried and incrementally mutated, so fix the
+            # dtype at init (LARGE_INT_DTYPE) and cast increments to match (scan carry rule)
+            blocked_spectrum=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
+            blocked_snr=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
+            blocked_power=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
             list_of_requests=list_of_requests,
             link_snr_array=init_link_snr_array(params),
             link_snr_array_prev=init_link_snr_array(params),

--- a/xlron/environments/gn_model/rsa_gn_model.py
+++ b/xlron/environments/gn_model/rsa_gn_model.py
@@ -81,6 +81,11 @@ class RSAGNModelEnv(RSAEnv):
             accepted_services=0,
             accepted_bitrate=0.0,
             total_bitrate=0.0,
+            # Blocking-cause counters: carried and incrementally mutated, so fix the
+            # dtype at init (LARGE_INT_DTYPE) and cast increments to match (scan carry rule)
+            blocked_spectrum=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
+            blocked_snr=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
+            blocked_power=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
             list_of_requests=list_of_requests,
             link_snr_array=init_link_snr_array(params),
             link_snr_array_prev=init_link_snr_array(params),

--- a/xlron/environments/rsa/rsa.py
+++ b/xlron/environments/rsa/rsa.py
@@ -22,7 +22,6 @@ from xlron.environments.diff_utils import *
 from xlron.environments.env_funcs import (
     calculate_fragmentation,
     calculate_path_stats,
-    check_action_rmsa_gn_model,
     check_action_rmsa_gn_model_components,
     check_action_rsa,
     check_action_rwalr,
@@ -268,7 +267,9 @@ class RSAEnv(environment.Environment):
             complete_step = complete_step_rsa_gn_model
         elif params.__class__.__name__ == "RMSAGNModelEnvParams":
             implement_action = implement_action_rmsa_gn_model
-            check_action = check_action_rmsa_gn_model
+            # check_action is deliberately not reassigned here: the RMSA GN-model check is
+            # computed below from check_action_rmsa_gn_model_components so the blocking
+            # cause (spectrum vs SNR vs power) can be counted without recomputation
             complete_step = complete_step_rmsa_gn_model
 
         # Implement action

--- a/xlron/environments/rsa/rsa.py
+++ b/xlron/environments/rsa/rsa.py
@@ -23,6 +23,7 @@ from xlron.environments.env_funcs import (
     calculate_fragmentation,
     calculate_path_stats,
     check_action_rmsa_gn_model,
+    check_action_rmsa_gn_model_components,
     check_action_rsa,
     check_action_rwalr,
     complete_step_rmsa_gn_model,
@@ -273,8 +274,27 @@ class RSAEnv(environment.Environment):
         # Implement action
         state = jit_profiler.call(params.profile, implement_action, state, action_info, params)
 
-        # Check action
-        check = jit_profiler.call(params.profile, check_action, state, action_info, params)
+        # Check action. For GN-model envs, keep the individual check components so the
+        # blocking cause (spectrum vs SNR vs power) can be counted without recomputation.
+        blocking_cause_checks = None
+        if params.__class__.__name__ == "RMSAGNModelEnvParams":
+            spectrum_check, snr_check, power_check = jit_profiler.call(
+                params.profile,
+                check_action_rmsa_gn_model_components,
+                state,
+                action_info,
+                params,
+            )
+            # Same aggregation (order included) as check_action_rmsa_gn_model
+            check = jnp.any(jnp.stack((spectrum_check, snr_check, power_check)))
+            blocking_cause_checks = (spectrum_check, snr_check, power_check)
+        else:
+            check = jit_profiler.call(params.profile, check_action, state, action_info, params)
+            if params.__class__.__name__ == "RSAGNModelEnvParams":
+                # rsa_gn_model has no SNR/power acceptance check at step time (SNR
+                # feasibility is enforced in the action mask), so every block observed
+                # here is attributed to spectrum contention
+                blocking_cause_checks = (check, jnp.array(False), jnp.array(False))
 
         # Calculate reward
         reward = jit_profiler.call(
@@ -283,6 +303,26 @@ class RSAEnv(environment.Environment):
 
         # Complete step
         state = jit_profiler.call(params.profile, complete_step, state, action_info, check, params)
+
+        # Update blocking-cause counters (GN-model envs only). Attribute each block with
+        # spectrum > SNR > power priority: a spectrum collision corrupts the tentative GN
+        # state, so downstream SNR/power failures would be spurious. The counters are
+        # therefore mutually exclusive and sum to the number of blocked requests.
+        if blocking_cause_checks is not None:
+            spectrum_check, snr_check, power_check = blocking_cause_checks
+            blocked_spectrum = jnp.asarray(spectrum_check).astype(jnp.bool_)
+            blocked_snr = jnp.asarray(snr_check).astype(jnp.bool_) & ~blocked_spectrum
+            blocked_power = jnp.asarray(power_check).astype(jnp.bool_) & ~(
+                blocked_spectrum | blocked_snr
+            )
+            gn_state = cast(GNModelEnvState, state)
+            state = gn_state.replace(
+                blocked_spectrum=gn_state.blocked_spectrum
+                + blocked_spectrum.astype(gn_state.blocked_spectrum.dtype),
+                blocked_snr=gn_state.blocked_snr + blocked_snr.astype(gn_state.blocked_snr.dtype),
+                blocked_power=gn_state.blocked_power
+                + blocked_power.astype(gn_state.blocked_power.dtype),
+            )
 
         # TODO (DYNAMIC-RWALR) - calculate allocated bandwidth
         # TODO (DYNAMIC-RWALR) - generate new request if allocated DR equals requested DR, else update requested DR do not advance time do not replace source-dest
@@ -315,6 +355,11 @@ class RSAEnv(environment.Environment):
         info["_accepted_services"] = state.accepted_services
         info["_accepted_bitrate"] = state.accepted_bitrate
         info["_total_bitrate"] = state.total_bitrate
+        if blocking_cause_checks is not None:
+            gn_state = cast(GNModelEnvState, state)
+            info["_blocked_spectrum"] = gn_state.blocked_spectrum
+            info["_blocked_snr"] = gn_state.blocked_snr
+            info["_blocked_power"] = gn_state.blocked_power
         # Band-gap sentinels (-1) are neither occupied nor usable spectrum, so count
         # positively-occupied slots over the usable (non-gap) slots only
         occupied_slots = jnp.count_nonzero(state.link_slot_array > 0)

--- a/xlron/environments/wrappers.py
+++ b/xlron/environments/wrappers.py
@@ -13,6 +13,7 @@ from jax import Array, tree_util
 
 from xlron import dtype_config
 from xlron.environments.dataclasses import (
+    GNModelEnvParams,
     LogEnvState,
     RSAEnvParams,
     RSAEnvState,
@@ -52,6 +53,9 @@ class LogWrapper(GymnaxWrapper):
             total_bitrate=jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE),
             utilisation=jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE),
             fragmentation=jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE),
+            blocked_spectrum=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
+            blocked_snr=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
+            blocked_power=jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE),
             terminal=jnp.array(False),
             truncated=jnp.array(False),
         )
@@ -82,6 +86,11 @@ class LogWrapper(GymnaxWrapper):
         fragmentation = info.pop(
             "_fragmentation", jnp.array(0, dtype=dtype_config.LARGE_FLOAT_DTYPE)
         )
+        # Blocking-cause counters are only stashed by GN-model envs; default to 0 elsewhere
+        zero_count = jnp.array(0, dtype=dtype_config.LARGE_INT_DTYPE)
+        blocked_spectrum = info.pop("_blocked_spectrum", zero_count)
+        blocked_snr = info.pop("_blocked_snr", zero_count)
+        blocked_power = info.pop("_blocked_power", zero_count)
         # Compute final episode length (for reporting) before resetting
         episode_length = log_state.lengths + 1
         cum_returns = log_state.cum_returns + reward
@@ -96,6 +105,9 @@ class LogWrapper(GymnaxWrapper):
             total_bitrate=total_bitrate,
             utilisation=utilisation,
             fragmentation=fragmentation,
+            blocked_spectrum=blocked_spectrum,
+            blocked_snr=blocked_snr,
+            blocked_power=blocked_power,
             terminal=terminal,
             truncated=truncated,
         )
@@ -109,6 +121,12 @@ class LogWrapper(GymnaxWrapper):
         info["total_bitrate"] = log_state.total_bitrate
         info["utilisation"] = log_state.utilisation
         info["fragmentation"] = log_state.fragmentation
+        # Report the blocking-cause breakdown for GN-model envs only (params is static,
+        # so info keys are consistent for a given env type)
+        if isinstance(params, GNModelEnvParams):
+            info["blocked_spectrum"] = log_state.blocked_spectrum
+            info["blocked_snr"] = log_state.blocked_snr
+            info["blocked_power"] = log_state.blocked_power
         info["terminal"] = terminal
         info["truncated"] = truncated
         # First check if we're dealing with RSAGNModelEnvParams

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -854,24 +854,40 @@ def reset_warmup_metric_counters(env_state):
     """Zero the metric counters accumulated during warmup.
 
     With continuous_operation the env is never reset, so the cumulative counters
-    (accepted_services, accepted_bitrate, total_bitrate) and the LogWrapper's
+    (accepted_services, accepted_bitrate, total_bitrate, and the GN-model
+    blocked_spectrum/blocked_snr/blocked_power counters) and the LogWrapper's
     lengths/cum_returns would otherwise include the near-zero-blocking network-fill
     transient, biasing every logged blocking probability (ENV_WARMUP_STEPS is
     documented as 'steps before collecting stats'). These fields are metrics-only;
     total_requests, which drives episode truncation, is deliberately kept.
     jnp.zeros_like preserves per-env shapes and dtypes for the jitted learner.
     """
+    inner_state = env_state.env_state
+    inner_updates = dict(
+        accepted_services=jnp.zeros_like(inner_state.accepted_services),
+        accepted_bitrate=jnp.zeros_like(inner_state.accepted_bitrate),
+        total_bitrate=jnp.zeros_like(inner_state.total_bitrate),
+    )
+    # GN-model env states also carry cumulative blocking-cause counters; zero them so
+    # spectrum/snr/power_blocking_probability exclude the warmup transient and keep
+    # summing to service_blocking_probability. hasattr inspects the static pytree
+    # structure (not traced values), so this branch is jit-safe.
+    if hasattr(inner_state, "blocked_spectrum"):
+        inner_updates.update(
+            blocked_spectrum=jnp.zeros_like(inner_state.blocked_spectrum),
+            blocked_snr=jnp.zeros_like(inner_state.blocked_snr),
+            blocked_power=jnp.zeros_like(inner_state.blocked_power),
+        )
     return env_state.replace(
         lengths=jnp.zeros_like(env_state.lengths),
         cum_returns=jnp.zeros_like(env_state.cum_returns),
         accepted_services=jnp.zeros_like(env_state.accepted_services),
         accepted_bitrate=jnp.zeros_like(env_state.accepted_bitrate),
         total_bitrate=jnp.zeros_like(env_state.total_bitrate),
-        env_state=env_state.env_state.replace(
-            accepted_services=jnp.zeros_like(env_state.env_state.accepted_services),
-            accepted_bitrate=jnp.zeros_like(env_state.env_state.accepted_bitrate),
-            total_bitrate=jnp.zeros_like(env_state.env_state.total_bitrate),
-        ),
+        blocked_spectrum=jnp.zeros_like(env_state.blocked_spectrum),
+        blocked_snr=jnp.zeros_like(env_state.blocked_snr),
+        blocked_power=jnp.zeros_like(env_state.blocked_power),
+        env_state=inner_state.replace(**inner_updates),
     )
 
 

--- a/xlron/train/train_utils.py
+++ b/xlron/train/train_utils.py
@@ -62,6 +62,13 @@ metrics = [
     "fragmentation",
     "service_blocking_probability",
     "bitrate_blocking_probability",
+    # Blocking-cause breakdown (GN-model envs only; keys absent for other env types)
+    "blocked_spectrum",
+    "blocked_snr",
+    "blocked_power",
+    "spectrum_blocking_probability",
+    "snr_blocking_probability",
+    "power_blocking_probability",
     "throughput",  # Only for RSA GN Model
     "launch_power",
     "path_snr",
@@ -1791,6 +1798,15 @@ def process_metrics(config, out, merge_func):
         merged_out["accepted_bitrate"]
         / jnp.where(merged_out["total_bitrate"] == 0, 1, merged_out["total_bitrate"])
     )
+
+    # Blocking-cause breakdown (GN-model envs only; keys absent for other env types).
+    # Causes are mutually exclusive, so these probabilities sum to
+    # service_blocking_probability.
+    if "blocked_spectrum" in merged_out:
+        lengths_safe = jnp.where(merged_out["lengths"] == 0, 1, merged_out["lengths"])
+        merged_out["spectrum_blocking_probability"] = merged_out["blocked_spectrum"] / lengths_safe
+        merged_out["snr_blocking_probability"] = merged_out["blocked_snr"] / lengths_safe
+        merged_out["power_blocking_probability"] = merged_out["blocked_power"] / lengths_safe
 
     # Calculate episode ends
     merged_out["done"] = jnp.logical_or(merged_out["terminal"], merged_out["truncated"])

--- a/xlron/train/train_utils_test.py
+++ b/xlron/train/train_utils_test.py
@@ -269,6 +269,47 @@ class ResetWarmupMetricCountersTest(absltest.TestCase):
         # total_requests drives episode truncation and must be preserved
         self.assertEqual(int(new_state.env_state.total_requests), total_requests_before)
 
+    def test_gn_model_blocking_cause_counters_zeroed(self):
+        """The GN-model blocking-cause counters accumulate during warmup too; if they are
+        not zeroed alongside lengths, spectrum/snr/power_blocking_probability divide
+        warmup-contaminated counts by post-warmup lengths and no longer sum to
+        service_blocking_probability (they can even exceed 1 early in a run).
+        """
+        settings = dict(
+            env_type="rmsa_gn_model",
+            topology_name="5node_directed",
+            k=2,
+            link_resources=5,
+            values_bw=[100],
+            slot_size=25,
+            guardband=0,
+            mod_format_correction=False,
+            load=100,
+            mean_service_holding_time=10,
+            max_requests=10,
+            continuous_operation=True,
+        )
+        env, params = make(settings)  # LogWrapper-wrapped
+        obs, state = env.reset(jax.random.PRNGKey(0), params)
+        # Simulate warmup-accumulated blocking-cause counts at both levels
+        count = jnp.array(2, dtype=state.env_state.blocked_spectrum.dtype)
+        state = state.replace(
+            blocked_spectrum=count,
+            blocked_snr=count,
+            blocked_power=count,
+            env_state=state.env_state.replace(
+                blocked_spectrum=count,
+                blocked_snr=count,
+                blocked_power=count,
+            ),
+        )
+
+        new_state = reset_warmup_metric_counters(state)
+
+        for field in ("blocked_spectrum", "blocked_snr", "blocked_power"):
+            self.assertEqual(int(getattr(new_state, field)), 0, f"LogEnvState.{field}")
+            self.assertEqual(int(getattr(new_state.env_state, field)), 0, f"env.{field}")
+
     def test_shapes_and_dtypes_preserved(self):
         state = self._stepped_log_state()
         new_state = reset_warmup_metric_counters(state)


### PR DESCRIPTION
# Add blocking-cause breakdown (spectrum vs SNR vs power) for GN-model envs

## What

Resolves the long-standing `# TODO - log failure reasons in info` in `check_action_rmsa_gn_model`: GN-model environments now count *why* each request was blocked — no free contiguous spectrum, insufficient SNR, or per-fibre power budget — and report the breakdown through the standard metrics pipeline (step info → LogWrapper → wandb/episode CSV/JSONL run summary).

This distinguishes spectrum-limited from physics-limited blocking, the key diagnostic for launch-power/margin tuning and for interpreting RL-vs-heuristic gaps in GN-model studies.

## How (per change)

- **`xlron/environments/env_funcs.py`** — `check_action_rmsa_gn_model` is split into `check_action_rmsa_gn_model_components` (returns the three raw check booleans) and an aggregator that keeps the exact `jnp.any(jnp.stack((rsa, snr, power)))` semantics, so acceptance behaviour is bit-identical.
- **`xlron/environments/dataclasses.py`** — new `blocked_spectrum`/`blocked_snr`/`blocked_power` counter fields on `GNModelEnvState` and `LogEnvState`.
- **`xlron/environments/rsa/rsa.py` (`step_env`)** — the RMSA-GN branch calls the components function once and derives the aggregate check from the same values (cheap: reuses the checks already computed every step, no recompute). Blocks are attributed with **spectrum > SNR > power priority**: a spectrum collision corrupts the tentatively-placed GN state, so SNR/power failures on such a step would be spurious. Counters are therefore mutually exclusive and sum to the number of blocked requests. Pre-reset values are stashed in info (`_blocked_*`) next to `_accepted_services`. All branching is on static params, so non-GN envs pay nothing.
- **`xlron/environments/gn_model/rsa_gn_model.py` / `rmsa_gn_model.py`** — counters initialised to `jnp.array(0, dtype=LARGE_INT_DTYPE)` at the init site; increments cast back to the carried dtype (scan-carry dtype rule from CLAUDE.md).
- **`xlron/environments/wrappers.py`** — `LogWrapper` carries the counters in `LogEnvState` (zero defaults for envs that don't stash them) and reports public `blocked_*` info keys only for `GNModelEnvParams` instances.
- **`xlron/train/train_utils.py`** — `blocked_*` and derived `spectrum/snr/power_blocking_probability` registered in the wandb `metrics` list; `process_metrics` computes the probabilities from `lengths` exactly like `service_blocking_probability` (they sum to it), guarded so non-GN runs are unaffected.
- **`docs/gn_model.md`** — new "Blocking-Cause Breakdown" section documenting the counters, the attribution rule, and the `rsa_gn_model` limitation.

### Scope note: `rsa_gn_model`

`rsa_gn_model` uses plain `check_action_rsa` at step time — SNR feasibility and power are enforced in its action mask, not the acceptance check — so there is no per-step SNR/power failure signal to count without adding new checks (which would change hot-path cost/semantics). Its blocks are all attributed to `blocked_spectrum` and the other counters stay zero; this is documented. `rmsa_gn_model` gets the full three-way breakdown.

## Tests added

`BlockingCauseCountersTest` in `xlron/environments/gn_model/gn_model_test.py` (8 tests):

- counters zero at reset and after an accepted request (masked valid action)
- **spectrum**: fully-occupied `link_slot_array` → only `blocked_spectrum` increments (even though the collision also corrupts the tentative GN state — priority test)
- **SNR**: fabricated existing connection with highest-order modulation and 1e-12 W power → only `blocked_snr` increments
- **power**: env with -90 dBm `max_power_per_fibre` and pinned 0 dBm `power_per_channel` → only `blocked_power` increments
- aggregate `check_action_rmsa_gn_model` equals `jnp.any` of the components
- `LogWrapper` pops the `_blocked_*` stashes and reports public keys + `LogEnvState` fields
- non-GN env (`rwa`): no counter fields on state, no `blocked_*` info keys, LogEnvState defaults stay zero

All targeted suites pass: gn_model (74), rsa+vone (804), env_funcs+make_env+dtype_config (274), heuristics (496), train smoke/utils/ppo (37); ruff + ty pre-commit hooks green.

## Behavior changes

- GN-model env states gain three int32 counter fields (env-state pytree structure change for `rsa_gn_model`/`rmsa_gn_model`); they accumulate within an episode and reset with it, like `accepted_services`.
- `LogEnvState` gains the same three fields for all env types (zeros for non-GN).
- GN-model envs report new info keys `blocked_spectrum`/`blocked_snr`/`blocked_power` (post-LogWrapper) and stash `_blocked_*` in raw step_env info; non-GN envs report nothing new.
- New wandb/CSV metrics: `blocked_*` counters plus `spectrum/snr/power_blocking_probability` (sum to `service_blocking_probability`); exported beyond the headline four only with `LOG_ALL_INFO`, matching the existing convention.
- **No change to acceptance semantics**: the aggregate validity check, rewards, terminals, and observations are unchanged.

---
*Follow-up batch (user-selected items from the July 2026 review). Each adversarially reviewed; full suite green per branch.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)