### PR TITLE
Unify dict-config defaults with CLI flag defaults (single source of truth in parameter_flags)

### DIFF
--- a/xlron/bounds/reconfigurable_routing_bounds_test.py
+++ b/xlron/bounds/reconfigurable_routing_bounds_test.py
@@ -24,6 +24,11 @@ def _rsa_4node_setup():
         values_bw=[1, 2],
         slot_size=1,
         guardband=0,
+        # The RR-bounds entry point forces absolute times (see
+        # reconfigurable_routing_bounds.py: relative_arrival_times=False) and the
+        # request tuples below carry absolute arrival/departure times; pin the same
+        # here since the flag default (now applied to dict configs too) is relative.
+        relative_arrival_times=False,
     )
     env, params = make(settings, log_wrapper=True)
     params_det = params.replace(deterministic_requests=True)

--- a/xlron/dtype_config.py
+++ b/xlron/dtype_config.py
@@ -106,9 +106,10 @@ def initialize_dtypes(flags: flags.FlagValues | Box | Dict) -> None:
     mixed_precision = bool(get_flag_value_or_none("mixed_precision", False))
     # Relative arrival times keep the simulation clock bounded by the holding time, which makes
     # 16-bit time arrays safe. Absolute time accumulates without bound -> keep float32.
-    # Default False to match make_env's internal default, so any config that omits the key
-    # conservatively keeps time at float32 (the --relative_arrival_times flag defaults True, so
-    # real runs through FLAGS still get the float16 memory win).
+    # Configs that reach here via process_config always carry the key (the flag default True is
+    # layered in from parameter_flags.get_flag_defaults), so real runs get the float16 memory
+    # win; the conservative False fallback below only applies to callers invoking
+    # initialize_dtypes directly with a partial dict, which keeps time at float32.
     relative_arrival_times = bool(get_flag_value_or_none("relative_arrival_times", False))
     # incremental_loading sets mean_service_holding_time ~1e6 (non-expiring requests), so even
     # relative departure values reach ~1e6 and overflow float16 -> force float32 times.

--- a/xlron/environments/env_funcs_test.py
+++ b/xlron/environments/env_funcs_test.py
@@ -141,6 +141,10 @@ def rsa_nsfnet_16_mod_test_setup(**kwargs):
         slot_size=12.5,
         mean_service_holding_time=10,
         env_type="rsa",
+        # Expectations in the tests below were computed with this modulations table
+        # (the pre-unification implicit default); the flag default is now
+        # modulations_deeprmsa.csv, so pin it explicitly.
+        modulations_csv_filepath="./xlron/data/modulations/modulations.csv",
     )
     if not kwargs:
         return _cached_setup("rsa_nsfnet_16_mod", base_settings)
@@ -470,7 +474,11 @@ class UpdatePathLinksTest(chex.TestCase):
 class RemoveExpiredSlotRequestsTest(chex.TestCase):
     def setUp(self):
         super().setUp()
-        self.key, self.env, self.obs, self.state, self.params = rwa_4node_test_setup()
+        # This test sets absolute departure/current times, so pin the absolute-time
+        # mode (the flag default, now applied to dict configs too, is relative).
+        self.key, self.env, self.obs, self.state, self.params = rwa_4node_test_setup(
+            relative_arrival_times=False
+        )
         # Set link 0, slots 0-1 as occupied (path=[1,0,0,0], initial_slot=0, num_slots=2)
         link_slot = self.state.link_slot_array.at[0, 0].set(1).at[0, 1].set(1)
         # Departure is now positive (time when service expires)

--- a/xlron/environments/gn_model/gn_model_test.py
+++ b/xlron/environments/gn_model/gn_model_test.py
@@ -1244,6 +1244,11 @@ class ActiveLightpathRegistryTest(chex.TestCase):
             include_no_op=False,
             load=100,
             mean_service_holding_time=25,
+            # The blocked-request check below asserts the departure registry is
+            # bit-identical across a step, which only holds for absolute times
+            # (under the relative-time flag default, every step rescales the
+            # stored departures).
+            relative_arrival_times=False,
         )
         return make(settings, log_wrapper=False)
 

--- a/xlron/environments/make_env.py
+++ b/xlron/environments/make_env.py
@@ -62,6 +62,7 @@ from xlron.environments.gn_model.isrs_gn_model_dra import (
     fit_dra_params_triangular,
 )
 from xlron.environments.wrappers import LogWrapper
+from xlron.parameter_flags import get_flag_defaults
 
 # Default KSP cache directory (next to the topology JSON files)
 KSP_CACHE_DIR = pathlib.Path(__file__).resolve().parent.parent / "data" / "topologies" / "ksp"
@@ -152,7 +153,7 @@ def validate_config(config: Box, is_eval: bool) -> None:
     end_first_blocking = config.get("end_first_blocking", False)
     if not continuous and not end_first_blocking:
         steps_per_env = int(config.NUM_UPDATES) * rollout_length
-        max_requests = int(config.get("max_requests", 0))
+        max_requests = int(config.get("max_requests", 4))
         if 0 < steps_per_env < max_requests:
             print(
                 f"WARNING: per-env rollout window (NUM_UPDATES * ROLLOUT_LENGTH = {steps_per_env}) "
@@ -170,9 +171,21 @@ def process_config(config: Optional[Union[dict, FlagValues]], **kwargs: Any) -> 
     # Allow config to be a dict or absl.flags.FlagValues
     if isinstance(config, FlagValues):
         config = {k: v.value for k, v in config.__flags.items()}
+    else:
+        config = dict(config)
     # if kwargs are passed, then include them in config
     config.update(kwargs)
-    config = Box(config)
+    # The GNN node-feature flag is uppercase DISABLE_NODE_FEATURES (train_utils.py
+    # sizes the GNN node input from it); accept the lowercase alias from dict-config
+    # callers before the flag defaults are layered in (after which the uppercase key
+    # is always present).
+    if "DISABLE_NODE_FEATURES" not in config and "disable_node_features" in config:
+        config["DISABLE_NODE_FEATURES"] = config["disable_node_features"]
+    # Layer user config over the flag defaults from parameter_flags.py, so dict-config
+    # callers (tests, notebooks, library users) get exactly the same defaults as a CLI
+    # run. For FlagValues configs this is a no-op (every flag key is already present).
+    # Must happen before initialize_dtypes below, which reads dtype-relevant keys.
+    config = Box({**get_flag_defaults(), **config})
     # Resolve the global dtype constants from this config BEFORE any env array is built.
     # Centralised here so every entry point (train, eval, bounds, GUI, tests) that goes through
     # make()/process_config() honours --mixed_precision and the per-tier *_dtype flags. Idempotent.
@@ -206,7 +219,7 @@ def process_config(config: Optional[Union[dict, FlagValues]], **kwargs: Any) -> 
         )
         config.maximise_throughput = config.maximise_throughout
     # This if statement is just to ensure compatibility with some tests that don't define all config options
-    if config.get("TOTAL_TIMESTEPS", False):
+    if config.get("TOTAL_TIMESTEPS"):
         config.TOTAL_TIMESTEPS = int(config.TOTAL_TIMESTEPS)
         requested_total_timesteps = config.TOTAL_TIMESTEPS
         # For incremental logging, we need to set the number of increments
@@ -219,7 +232,7 @@ def process_config(config: Optional[Union[dict, FlagValues]], **kwargs: Any) -> 
         # The eval scan runs max_requests*scale_factor steps per episode, and NUM_EPISODES
         # = STEPS_PER_INCREMENT // (max_requests * scale_factor) // NUM_ENVS.
         if is_eval and not config.get("continuous_operation", False):
-            max_requests = int(config.get("max_requests", 1000))
+            max_requests = int(config.get("max_requests", 4))
             scale_factor = int(config.get("scale_factor", 1))
             episode_length = max_requests * scale_factor
             min_steps = episode_length * config.NUM_ENVS
@@ -315,7 +328,7 @@ def make(
         params: Environment parameters
     """
     config = process_config(config, **kwargs)
-    env_type = config.get("env_type", "").lower()
+    env_type = config.get("env_type", "rmsa").lower()
     if env_type not in [
         "rsa",
         "rmsa",
@@ -330,19 +343,17 @@ def make(
         raise ValueError(f"Invalid environment type {env_type}")
 
     seed = config.get("seed", 0)
-    topology_name = config.get("topology_name", "conus")
-    load = config.get("load", 100)
+    topology_name = config.get("topology_name", "4node")
+    load = config.get("load", 250)
     k = config.get("k", 5)
     incremental_loading = config.get("incremental_loading", False)
     end_first_blocking = config.get("end_first_blocking", False)
     terminate_on_episode_end = config.get("terminate_on_episode_end", False)
     random_traffic = config.get("random_traffic", False)
     continuous_operation = config.get("continuous_operation", False)
-    total_timesteps = config.get("TOTAL_TIMESTEPS", 1e4)
-    max_requests = (
-        total_timesteps if continuous_operation else config.get("max_requests", total_timesteps)
-    )
-    link_resources = config.get("link_resources", 100)
+    total_timesteps = config.get("TOTAL_TIMESTEPS", 1e6)
+    max_requests = total_timesteps if continuous_operation else config.get("max_requests", 4)
+    link_resources = config.get("link_resources", 5)
     values_bw = config.get("values_bw", None)
     values_bw_probs = config.get("values_bw_probs", None)
     node_probabilities = config.get("node_probs", None)
@@ -360,22 +371,17 @@ def make(
     traffic_requests_csv_filepath = config.get("traffic_requests_csv_filepath", None)
     multiple_topologies_directory = config.get("multiple_topologies_directory", None)
     aggregate_slots = config.get("aggregate_slots", 1)
-    # The flag is uppercase DISABLE_NODE_FEATURES (train_utils.py sizes the GNN node input
-    # from it); accept the lowercase key too for dict-config callers.
-    disable_node_features = config.get(
-        "DISABLE_NODE_FEATURES", config.get("disable_node_features", False)
-    )
+    # The lowercase disable_node_features alias is resolved in process_config
+    disable_node_features = config.get("DISABLE_NODE_FEATURES", False)
     disjoint_paths = config.get("disjoint_paths", False)
     log_actions = config.get("log_actions", False)
     profile = config.get("PROFILE", False)
     guardband = config.get("guardband", 1)
     maximum_path_length_km = config.get("maximum_path_length_km", None)
-    path_sort_criteria = config.get("path_sort_criteria", "hops")
+    path_sort_criteria = config.get("path_sort_criteria", "spectral_resources")
     remove_array_wrappers = config.get("remove_array_wrappers", False)
-    # "maximise_throughout" is the deprecated misspelling (see process_config)
-    maximise_throughput = config.get(
-        "maximise_throughput", config.get("maximise_throughout", False)
-    )
+    # The deprecated misspelling "maximise_throughout" is resolved in process_config
+    maximise_throughput = config.get("maximise_throughput", False)
     reward_type = config.get("reward_type", "service")
     truncate_holding_time = config.get("truncate_holding_time", False)
     alpha = config.get("alpha", 0.2) * 1e-3
@@ -389,9 +395,9 @@ def make(
         raise ValueError("Cannot aggregate slots and evaluate heuristic")
 
     # VONE specific parameters
-    node_resources = config.get("node_resources", 30)
+    node_resources = config.get("node_resources", 4)
     min_node_resources = config.get("min_node_resources", 1)
-    max_node_resources = config.get("max_node_resources", 2)
+    max_node_resources = config.get("max_node_resources", 1)
     virtual_topologies = config.get("virtual_topologies", "3_ring")
     virtual_topologies = (
         virtual_topologies.split(",") if isinstance(virtual_topologies, str) else virtual_topologies
@@ -423,8 +429,8 @@ def make(
     attenuation = config.get("attenuation", 0.2 / 4.343 / 1e3)
     attenuation_bar = config.get("attenuation_bar", 0.2 / 4.343 / 1e3)
     dispersion_coeff = config.get("dispersion_coeff", 17 * 1e-12 / 1e-9 / 1e3)
-    dispersion_slope = config.get("dispersion_slope", 0.067 * 1e-12 / 1e-9 / 1e3 / 1e-9)
-    coherent = config.get("coherent", False)
+    dispersion_slope = config.get("dispersion_slope", 60.7)
+    coherent = config.get("coherent", True)
     config.get("noise_figure", 4)
     uniform_spans = config.get("uniform_spans", True)
     band_preference = config.get("band_preference", None)
@@ -458,7 +464,7 @@ def make(
         ref_lambda = _band_layout["ref_lambda"]
         gap_start_slots = _band_layout["gap_start_slots"]
         gap_width_slots = _band_layout["gap_width_slots"]
-    elif config.get("enforce_band_gaps", False):
+    elif config.get("enforce_band_gaps", True):
         gap_start_slots, gap_width_slots = compute_band_gaps_from_csv(
             link_resources, ref_lambda, slot_size, config.get("band_data_filepath", None)
         )
@@ -475,19 +481,19 @@ def make(
                 f"got {len(gap_width_slots)} widths and {len(gap_start_slots)} starts"
             )
     mod_format_correction = (
-        config.get("mod_format_correction", True) if env_type == "rmsa_gn_model" else False
+        config.get("mod_format_correction", False) if env_type == "rmsa_gn_model" else False
     )
     num_roadms = config.get("num_roadms", 1)
     roadm_loss = config.get("roadm_loss", 18)
     span_lumped_loss_db = config.get("span_lumped_loss_db", None)
-    snr_margin = config.get("snr_margin", 1)
+    snr_margin = config.get("snr_margin", 0.5)
     path_snr = True if env_type in ["rsa_gn_model", "rmsa_gn_model"] else False
-    max_snr = config.get("max_snr", 50.0)
+    max_snr = config.get("max_snr", 30.0)
     min_snr = config.get("min_snr", 7.0)
-    max_power = config.get("max_power", 9)
+    max_power = config.get("max_power", 0.5)
     min_power = config.get("min_power", -5)
-    step_power = config.get("step_power", 1)
-    max_power_per_fibre_dbm = config.get("max_power_per_fibre", 21.0)
+    step_power = config.get("step_power", 0.1)
+    max_power_per_fibre_dbm = config.get("max_power_per_fibre", 23.0)
     max_power_per_fibre = float(from_dbm(max_power_per_fibre_dbm))  # linear Watts
     power_per_channel_dbm = config.get("power_per_channel", None)
     if power_per_channel_dbm is not None:
@@ -499,10 +505,10 @@ def make(
     traffic_array = config.get("traffic_array", False)
     launch_power_array = config.get("launch_power_array", None)
     pack_path_bits = config.get("pack_path_bits", False)
-    relative_arrival_times = config.get("relative_arrival_times", False)
+    relative_arrival_times = config.get("relative_arrival_times", True)
 
     # Differentiable approximation params
-    temperature = config.get("temperature", 1.0)
+    temperature = config.get("temperature", 5.0)
     differentiable = config.get("differentiable", False)
 
     # optimize_launch_power.py parameters
@@ -512,7 +518,7 @@ def make(
     rng, _, _, _, _ = jax.random.split(rng, 5)
     graph = make_graph(topology_name, topology_directory=config.get("topology_directory", None))
     traffic_intensity = config.get("traffic_intensity", 0)
-    mean_service_holding_time = config.get("mean_service_holding_time", 10)
+    mean_service_holding_time = config.get("mean_service_holding_time", 25)
 
     # Precision guard for the time/departure arrays. These hold (current_time + holding_time).
     # NB the previous guard used ``isinstance(dtype, jnp.bfloat16)`` which is always False (the
@@ -638,13 +644,13 @@ def make(
             list_of_requests = np.loadtxt(traffic_requests_csv_filepath, delimiter=",")[1:, :]
             list_of_requests = jnp.array(list_of_requests)
         elif config.get("list_of_requests", None) is not None:
-            list_of_requests = jnp.array(config.get("list_of_requests", [0.0]), dtype=jnp.float32)
+            list_of_requests = jnp.array(config.list_of_requests, dtype=jnp.float32)
         else:
             list_of_requests = init_list_of_requests(int(max_requests))
         max_requests = len(list_of_requests)
     elif optimise_launch_power:
         deterministic_requests = True
-        list_of_requests = jnp.array(config.get("list_of_requests", [0.0]))
+        list_of_requests = jnp.array(config.get("list_of_requests") or [0.0])
     else:
         deterministic_requests = False
         list_of_requests = jnp.array([0.0])
@@ -696,7 +702,7 @@ def make(
     max_spans = int(jnp.ceil(max(link_length_array) * 1e3 / max_span_length)[0])
     if consider_modulation_format:
         modulations_array = init_modulations_array(config.get("modulations_csv_filepath", None))
-        if config.get("calc_minimum_osnr", False):
+        if config.get("calc_minimum_osnr", True):
             beta_fec = config.get("beta_fec", 1.5e-2)
             modulations_array = jnp.array(
                 _calc_modulations_osnr(np.array(modulations_array), beta_fec)
@@ -801,7 +807,7 @@ def make(
     else:
         line_graph_spectral_features = None
 
-    transformer_obs_type = config.get("transformer_obs_type", "")
+    transformer_obs_type = config.get("transformer_obs_type", "departure")
     if transformer_obs_type:
         assert transformer_obs_type in ["departure", "occupancy", "capacity"], (
             f"transformer_obs_type must be one of 'departure', 'occupancy', or 'capacity', got {transformer_obs_type}"
@@ -863,9 +869,9 @@ def make(
         relative_arrival_times=relative_arrival_times,
         temperature=temperature,
         differentiable=differentiable,
-        num_spectral_features=config.get("num_spectral_features", 3),
+        num_spectral_features=config.get("num_spectral_features", 8),
         line_graph_spectral_features=line_graph_spectral_features,
-        include_no_op=config.get("include_no_op", True),
+        include_no_op=config.get("include_no_op", False),
         transformer_obs_type=transformer_obs_type,
         use_gnn=config.get("USE_GNN"),
         profile=profile,

--- a/xlron/environments/make_env_test.py
+++ b/xlron/environments/make_env_test.py
@@ -158,3 +158,140 @@ def test_matching_eval_config_is_quiet(capsys):
     # SPI exactly fits one episode and divides TOTAL_TIMESTEPS: no warnings expected.
     process_config(_eval_cfg(STEPS_PER_INCREMENT=10000, TOTAL_TIMESTEPS=10000))
     assert "WARNING" not in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Flag defaults as single source of truth for dict-config callers
+# ---------------------------------------------------------------------------
+
+
+def test_process_config_empty_dict_uses_flag_defaults():
+    """Dict-config callers omitting a key must get the CLI (parameter_flags) default.
+
+    Regression test: make_env used to hardcode config.get() fallbacks that diverged
+    from the flag defaults (e.g. include_no_op True vs flag False), so tests and
+    library users silently got different behaviour from an identical CLI run.
+    """
+    from xlron.parameter_flags import get_flag_defaults
+
+    defaults = get_flag_defaults()
+    config = process_config({})
+    # The historically divergent keys (fallback != flag default before the fix):
+    for key in [
+        "include_no_op",
+        "calc_minimum_osnr",
+        "relative_arrival_times",
+        "path_sort_criteria",
+        "mean_service_holding_time",
+        "num_spectral_features",
+        "max_power_per_fibre",
+        "max_snr",
+        "snr_margin",
+        "max_power",
+        "step_power",
+        "enforce_band_gaps",
+        "coherent",
+        "mod_format_correction",
+        "temperature",
+        "topology_name",
+        "load",
+        "link_resources",
+        "env_type",
+        "node_resources",
+        "max_node_resources",
+        "modulations_csv_filepath",
+        "transformer_obs_type",
+        "dispersion_slope",
+    ]:
+        assert config[key] == defaults[key], (
+            f"process_config default for {key!r} ({config[key]!r}) does not match "
+            f"the parameter_flags default ({defaults[key]!r})"
+        )
+    # Every flag key must be present after layering (no more silent fallbacks).
+    missing = set(defaults) - set(config)
+    assert not missing, f"flag keys missing from processed config: {sorted(missing)}"
+
+
+def test_process_config_user_config_overrides_flag_defaults():
+    config = process_config(
+        dict(mean_service_holding_time=10, include_no_op=True, relative_arrival_times=False)
+    )
+    assert config.mean_service_holding_time == 10
+    assert config.include_no_op is True
+    assert config.relative_arrival_times is False
+
+
+def test_dict_config_flag_defaults_reach_params():
+    """make() with a minimal dict resolves omitted keys to the CLI flag defaults."""
+    settings = dict(
+        env_type="rwa",
+        topology_name="4node",
+        link_resources=4,
+        k=2,
+        load=100,
+        max_requests=10,
+        values_bw=[1],
+        slot_size=1,
+    )
+    _, params = make(settings, log_wrapper=False)
+    assert params.include_no_op is False  # flag default; old dict fallback was True
+    assert params.relative_arrival_times is True  # flag default; old dict fallback was False
+    assert params.mean_service_holding_time == 25.0  # flag default; old dict fallback was 10
+    assert params.num_spectral_features == 8  # flag default; old dict fallback was 3
+
+
+def test_make_env_config_get_fallbacks_match_flag_defaults():
+    """Any literal config.get() fallback in make_env.py for a flag-backed key must
+    equal the parameter_flags default.
+
+    The fallbacks are dead code for configs that pass through process_config (which
+    layers in every flag default), but keeping them aligned prevents silent divergence
+    for any future code path that bypasses the layering. Fallbacks of None are treated
+    as presence checks and skipped, as are non-literal (computed) fallbacks.
+    """
+    import ast
+    import inspect
+
+    from xlron.environments import make_env
+    from xlron.parameter_flags import get_flag_defaults
+
+    defaults = get_flag_defaults()
+    tree = ast.parse(inspect.getsource(make_env))
+
+    def matches(fallback, default):
+        if fallback is None:
+            return True  # presence-check idiom
+        if isinstance(fallback, bool) != isinstance(default, bool):
+            return False
+        try:
+            return float(fallback) == float(default)
+        except (TypeError, ValueError):
+            return fallback == default
+
+    violations = []
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "config"
+            and len(node.args) == 2
+            and isinstance(node.args[0], ast.Constant)
+        ):
+            continue
+        key = node.args[0].value
+        if key not in defaults:
+            continue  # not a CLI flag (e.g. lowercase aliases, script-only keys)
+        try:
+            fallback = ast.literal_eval(node.args[1])
+        except (ValueError, SyntaxError, TypeError):
+            continue  # computed fallback, cannot compare statically
+        if defaults[key] is None and fallback is not None:
+            violations.append((node.lineno, key, fallback, defaults[key]))
+        elif defaults[key] is not None and not matches(fallback, defaults[key]):
+            violations.append((node.lineno, key, fallback, defaults[key]))
+    assert not violations, (
+        "config.get() fallbacks in make_env.py diverge from parameter_flags defaults "
+        f"(line, key, fallback, flag default): {violations}"
+    )

--- a/xlron/environments/rsa/rsa_test.py
+++ b/xlron/environments/rsa/rsa_test.py
@@ -280,7 +280,11 @@ class RsaResetTest(chex.TestCase):
 class RsaActionMaskTest(chex.TestCase):
     def setUp(self):
         super().setUp()
-        self.key, self.env, self.obs, self.state, self.params = rwa_4node_test_setup()
+        # Expected masks below include the trailing no-op action, so pin
+        # include_no_op=True (the flag default, now applied to dict configs too, is False).
+        self.key, self.env, self.obs, self.state, self.params = rwa_4node_test_setup(
+            include_no_op=True
+        )
 
     @chex.all_variants()
     @parameterized.named_parameters(
@@ -442,8 +446,8 @@ class RsaActionMaskTest(chex.TestCase):
         ),
     )
     def test_rsa_action_mask_3_slot_request(self, request_array, link_slot_array, expected):
-        self.key, self.env, self.obs, self.state, self.params = (
-            rsa_4node_3_slot_request_test_setup()
+        self.key, self.env, self.obs, self.state, self.params = rsa_4node_3_slot_request_test_setup(
+            include_no_op=True
         )
         self.state = self.state.replace(
             request_array=request_array, link_slot_array=link_slot_array
@@ -694,7 +698,13 @@ class RsaActionMaskTest(chex.TestCase):
         self, request_array, consider_mod, link_slot_array, expected
     ):
         self.key, self.env, self.obs, self.state, self.params = rsa_nsfnet_16_test_setup(
-            guardband=0, env_type="rmsa"
+            guardband=0,
+            env_type="rmsa",
+            include_no_op=True,
+            # Expectations were computed with this modulations table (the
+            # pre-unification implicit default); the flag default is now
+            # modulations_deeprmsa.csv, so pin it explicitly.
+            modulations_csv_filepath="./xlron/data/modulations/modulations.csv",
         )
         self.state = self.state.replace(
             request_array=request_array, link_slot_array=link_slot_array
@@ -797,6 +807,10 @@ def rsa_multiband_4node_test_setup(**kwargs):
         # 25 GHz gap starting at 100 GHz -> 2-slot gap at slots 8-9
         interband_gap_width=[25],
         interband_gap_start=[100],
+        # These tests exercise the custom interband_gap_* branch, which is only
+        # reached when enforce_band_gaps is off (the flag default, now applied to
+        # dict configs too, is True = CSV-derived band gaps).
+        enforce_band_gaps=False,
     )
     settings.update(kwargs)
     key = jax.random.PRNGKey(0)

--- a/xlron/environments/rwa_lightpath_reuse/rwa_lightpath_reuse_test.py
+++ b/xlron/environments/rwa_lightpath_reuse/rwa_lightpath_reuse_test.py
@@ -28,35 +28,43 @@ def _rwa_lr_cached_setup(cache_key, settings):
     return key, env, obs, state, params
 
 
-def rwa_lightpath_reuse_4_nsfnet_test_setup():
-    return _rwa_lr_cached_setup(
-        "rwa_lr_nsfnet_4",
-        dict(
-            k=5,
-            topology_name="nsfnet_deeprmsa_undirected",
-            link_resources=4,
-            max_requests=1000,
-            values_bw=[100],
-            incremental_loading=True,
-            env_type="rwa_lightpath_reuse",
-            scale_factor=1.0,
-        ),
+def rwa_lightpath_reuse_4_nsfnet_test_setup(**kwargs):
+    settings = dict(
+        k=5,
+        topology_name="nsfnet_deeprmsa_undirected",
+        link_resources=4,
+        max_requests=1000,
+        values_bw=[100],
+        incremental_loading=True,
+        env_type="rwa_lightpath_reuse",
+        scale_factor=1.0,
     )
+    if not kwargs:
+        return _rwa_lr_cached_setup("rwa_lr_nsfnet_4", settings)
+    settings.update(kwargs)
+    key = jax.random.PRNGKey(0)
+    env, params = make(settings, log_wrapper=False)
+    obs, state = env.reset(key, params)
+    return key, env, obs, state, params
 
 
-def rwa_lightpath_reuse_4node_test_setup():
-    return _rwa_lr_cached_setup(
-        "rwa_lr_4node",
-        dict(
-            k=2,
-            topology_name="4node",
-            link_resources=4,
-            max_requests=1000,
-            values_bw=[100],
-            incremental_loading=True,
-            env_type="rwa_lightpath_reuse",
-        ),
+def rwa_lightpath_reuse_4node_test_setup(**kwargs):
+    settings = dict(
+        k=2,
+        topology_name="4node",
+        link_resources=4,
+        max_requests=1000,
+        values_bw=[100],
+        incremental_loading=True,
+        env_type="rwa_lightpath_reuse",
     )
+    if not kwargs:
+        return _rwa_lr_cached_setup("rwa_lr_4node", settings)
+    settings.update(kwargs)
+    key = jax.random.PRNGKey(0)
+    env, params = make(settings, log_wrapper=False)
+    obs, state = env.reset(key, params)
+    return key, env, obs, state, params
 
 
 class CheckLightpathAvailableAndExistingTest(chex.TestCase):
@@ -232,8 +240,10 @@ class CheckLightpathAvailableAndExistingTest(chex.TestCase):
 class MaskSlotsRWALightpathReuseTest(chex.TestCase):
     def setUp(self):
         super().setUp()
+        # Expected masks below include the trailing no-op action, so pin
+        # include_no_op=True (the flag default, now applied to dict configs too, is False).
         self.key, self.env, self.obs, self.state, self.params = (
-            rwa_lightpath_reuse_4node_test_setup()
+            rwa_lightpath_reuse_4node_test_setup(include_no_op=True)
         )
 
     @chex.all_variants()
@@ -621,8 +631,12 @@ class MaskSlotsRWALightpathReuseTest(chex.TestCase):
 class RWALightpathReuseTest(chex.TestCase):
     def setUp(self):
         super().setUp()
+        # test_end_episode samples actions from the mask, so the expected capacities
+        # depend on the action-space size and path ordering: pin include_no_op=True
+        # and path_sort_criteria="hops" (the flag defaults, now applied to dict
+        # configs too, are False and "spectral_resources").
         self.key, self.env, self.obs, self.state, self.params = (
-            rwa_lightpath_reuse_4_nsfnet_test_setup()
+            rwa_lightpath_reuse_4_nsfnet_test_setup(include_no_op=True, path_sort_criteria="hops")
         )
 
     @chex.all_variants()
@@ -822,6 +836,10 @@ class DynamicExpiryCapacityRestoreTest(chex.TestCase):
             scale_factor=1.0,
             load=100,
             mean_service_holding_time=25,
+            # This test drives expiry with an absolute far-future current_time, so pin
+            # the absolute-time mode (the flag default, now applied to dict configs
+            # too, is relative).
+            relative_arrival_times=False,
         )
         env, params = make(settings, log_wrapper=False)
         key = jax.random.PRNGKey(0)

--- a/xlron/parameter_flags.py
+++ b/xlron/parameter_flags.py
@@ -990,3 +990,20 @@ flags.DEFINE_float(
     0.8,
     "Sigma for Gaussian smoothing kernel (larger = smoother landscape)",
 )
+
+
+def get_flag_defaults() -> dict:
+    """Return ``{flag_name: default_value}`` for every flag defined in this module.
+
+    This makes the flag definitions above the single source of truth for parameter
+    defaults: ``make_env.process_config`` layers user-supplied config keys over
+    these defaults, so dict-config callers (tests, notebooks, library users) get
+    exactly the same defaults as a CLI run. Flag ``.default`` values are readable
+    without parsing argv, so this is safe to call at any time.
+    """
+    module_flags = flags.FLAGS.flags_by_module_dict().get(__name__)
+    if not module_flags:  # pragma: no cover - defensive; absl keys flags by defining module
+        raise RuntimeError(
+            f"No flags registered under module {__name__!r}; cannot derive config defaults."
+        )
+    return {f.name: f.default for f in module_flags}


### PR DESCRIPTION
# Unify dict-config defaults with CLI flag defaults

## What

`make()` hardcoded `config.get(key, fallback)` literals that contradicted the authoritative flag defaults in `xlron/parameter_flags.py`. Any caller constructing an environment from a plain dict (tests, notebooks, library users bypassing absl) that omitted a key silently got different behaviour from an identical CLI run — e.g. `include_no_op` (fallback `True` vs flag `False`) changes the action-space size, and `relative_arrival_times` (fallback `False` vs flag `True`) changes time semantics and the TIME dtype tier.

### Changes

- **`xlron/parameter_flags.py`**: new `get_flag_defaults()` returns `{flag_name: default}` for every flag defined in the module, read from the absl registry (`FLAGS.flags_by_module_dict()`); flag `.default` values are readable without parsing argv, so this is safe at import/call time.
- **`xlron/environments/make_env.py` (`process_config`)**: user config is layered over `get_flag_defaults()` — `Box({**get_flag_defaults(), **config})` — before `dtype_config.initialize_dtypes()` (which reads `relative_arrival_times`/`incremental_loading`/`mixed_precision`). For `FlagValues` configs this is a **no-op** (every flag key is already present), guaranteeing zero CLI change. The lowercase `disable_node_features` alias is promoted to `DISABLE_NODE_FEATURES` before layering so it keeps working now that the uppercase key is always present.
- **`xlron/environments/make_env.py` (`make`, `validate_config`)**: the now-dead literal fallbacks were aligned to the flag defaults as defense in depth (they cannot fire for configs passing through `process_config`). Two alias-chain `config.get(...)` idioms were simplified since the aliases are resolved in `process_config`.
- **`xlron/dtype_config.py`**: comment update only (the `relative_arrival_times` fallback note referenced the old divergent make_env default).

## Why

parameter_flags.py is documented (and treated by the CLI, GUI and bounds scripts) as the source of truth for defaults, but tests and library users got a second, divergent set of defaults. This made test behaviour unrepresentative of CLI runs and made "same config, different entry point" produce different environments.

## Divergence table (dict-config behavior changes)

Effective default for **dict-config callers omitting the key** — CLI runs always used the "new unified default" column already:

| key | old dict default | new unified default |
|---|---|---|
| `include_no_op` | `True` | `False` (action space loses trailing no-op) |
| `relative_arrival_times` | `False` | `True` |
| `path_sort_criteria` | `"hops"` | `"spectral_resources"` |
| `calc_minimum_osnr` | `False` | `True` |
| `modulations_csv_filepath` | `None` (→ `modulations.csv`) | `./xlron/data/modulations/modulations_deeprmsa.csv` |
| `mean_service_holding_time` | `10` | `25` |
| `num_spectral_features` | `3` | `8` |
| `max_power_per_fibre` | `21.0` dBm | `23.0` dBm (also shifts default per-channel launch power) |
| `max_snr` | `50.0` | `30.0` |
| `snr_margin` | `1` | `0.5` |
| `max_power` | `9` | `0.5` |
| `step_power` | `1` | `0.1` |
| `enforce_band_gaps` | `False` | `True` (CSV-derived band gaps unless disabled) |
| `coherent` | `False` | `True` |
| `mod_format_correction` (rmsa_gn_model) | `True` | `False` |
| `temperature` | `1.0` | `5.0` |
| `dispersion_slope` | `67.0` (computed) | `60.7` |
| `env_type` | `""` (raised ValueError) | `"rmsa"` |
| `topology_name` | `"conus"` | `"4node"` |
| `load` | `100` | `250` |
| `link_resources` | `100` | `5` |
| `TOTAL_TIMESTEPS` | `1e4` | `1e6` |
| `max_requests` (episodic, omitted) | `TOTAL_TIMESTEPS` | `4` |
| `node_resources` | `30` | `4` |
| `max_node_resources` | `2` | `1` |
| `transformer_obs_type` | `""` | `"departure"` |

Additionally, dict configs now always enter the derived-config branch of `process_config` (`NUM_INCREMENTS`/`NUM_UPDATES`/`MINIBATCH_SIZE` computed, `validate_config` warnings printed), same as every CLI run.

## Behavior changes

- **CLI runs: none**, with one corner exception: `optimise_launch_power=True` with `list_of_requests` unset previously crashed (`jnp.array(None)` TypeError); it now falls back to `[0.0]` (`make_env.py`, `config.get("list_of_requests") or [0.0]`).
- **Dict-config runs**: only where they silently diverged from documented CLI defaults — see table above.
- Under `--mixed_precision`, dict configs omitting `relative_arrival_times` now get the float16 TIME_DTYPE memory win (key resolves to the flag default `True`), matching CLI.

## Tests

New in `xlron/environments/make_env_test.py`:
- `test_process_config_empty_dict_uses_flag_defaults` — every historically divergent key resolves to the flag default; all flag keys present after layering (fails before the fix).
- `test_process_config_user_config_overrides_flag_defaults` — explicit keys still win.
- `test_dict_config_flag_defaults_reach_params` — flag defaults reach `EnvParams` through `make()` (fails before the fix).
- `test_make_env_config_get_fallbacks_match_flag_defaults` — AST scan of `make_env.py` asserting every literal `config.get()` fallback for a flag-backed key equals the flag default (`None` fallbacks are presence-check idioms and skipped), preventing future drift.

Existing fixtures that relied on the old divergent dict defaults now pin them explicitly (preserving each test's intent):
- `env_funcs_test.py`: `rsa_nsfnet_16_mod_test_setup` pins `modulations.csv`; `RemoveExpiredSlotRequestsTest` pins `relative_arrival_times=False` (it drives absolute departure times).
- `rsa/rsa_test.py`: `RsaActionMaskTest` pins `include_no_op=True` (expected masks include the no-op) and `modulations.csv` for the nsfnet rmsa case; the multiband gap fixture pins `enforce_band_gaps=False` (those tests exercise the custom `interband_gap_*` branch).
- `rwa_lightpath_reuse_test.py`: setup helpers accept `**kwargs`; mask/end-episode tests pin `include_no_op=True` (+ `path_sort_criteria="hops"` for the trajectory-dependent capacities); the expiry test pins `relative_arrival_times=False`.
- `gn_model_test.py`: registry lifecycle test pins `relative_arrival_times=False` (asserts bit-identical departures across a blocked step).
- `reconfigurable_routing_bounds_test.py`: pins `relative_arrival_times=False`, matching the value the RR-bounds entry point forces internally.

All targeted suites pass locally (make_env, env_funcs, dtype_config, rsa, vone, rwa_lightpath_reuse, gn_model, heuristics, ppo, train_utils, models, bounds, diff_utils, train_smoke).

## Not done (follow-up candidates)

- `xlron/gui/widgets.py` `DEFAULTS` is a third hand-maintained copy of defaults (currently consistent per review); it could be auto-derived from `get_flag_defaults()`.
- A few non-flag keys keep their local fallbacks by design (`seed`, `amplifier_noise_figure`, `noise_figure`, `num_roadms`, `roadm_loss`, `raman_fit_method`, `remove_array_wrappers`, `launch_power_array`, `num_spans`).

---
*Follow-up batch (user-selected items from the July 2026 review). Each adversarially reviewed; full suite green per branch.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)