### PR TITLE
Extend launch_power_type=rl support to rmsa_gn_model

### DIFF
--- a/xlron/environments/gn_model/gn_model_test.py
+++ b/xlron/environments/gn_model/gn_model_test.py
@@ -476,6 +476,65 @@ class RMSAGNModelMaskTest(chex.TestCase):
         self.assertTrue(isinstance(truncated, jax.Array))
 
 
+class RMSAGNModelLogWrapperTest(chex.TestCase):
+    """LogWrapper must unpack [path_slot_action, launch_power] actions for the RMSA GN env.
+
+    Regression: is_gn_params previously tested isinstance(params, RSAGNModelEnvParams),
+    which RMSAGNModelEnvParams is not (both are siblings deriving from GNModelEnvParams),
+    so for rmsa_gn_model + launch_power_type=rl the 2-element action leaked into
+    process_path_action (vector path/slot indices under log_actions) and
+    info["launch_power"] was never logged.
+    """
+
+    def setUp(self):
+        super().setUp()
+        settings = dict(
+            k=4,
+            topology_name="nsfnet_deeprmsa_directed",
+            link_resources=10,
+            max_requests=100,
+            values_bw=[100],
+            incremental_loading=True,
+            env_type="rmsa_gn_model",
+            slot_size=12.5,
+            guardband=0,
+            mod_format_correction=False,
+            max_power_per_fibre=10.0,
+            coherent=False,
+            include_no_op=False,
+            launch_power_type="rl",
+        )
+        self.key = jax.random.PRNGKey(3)
+        if "rmsa_gn_model_log_wrapper" not in _gn_cache:
+            # log_wrapper defaults to True: the wrapped env is the object under test
+            _gn_cache["rmsa_gn_model_log_wrapper"] = make(settings)
+        self.env, self.params = _gn_cache["rmsa_gn_model_log_wrapper"]
+        self.obs, self.state = self.env.reset(self.key, self.params)
+
+    def test_step_unpacks_path_power_action(self):
+        rng_sample, rng_step = jax.random.split(self.key)
+        mask, _, mod_format_mask = self.env.action_mask(self.state.env_state, self.params)
+        inner = self.state.env_state.replace(link_slot_mask=mask, mod_format_mask=mod_format_mask)
+        state = self.state.replace(env_state=inner)
+        action_dist = distrax.Categorical(logits=jnp.where(mask > 0, 0.0, -1e8))
+        path_action = action_dist.sample(seed=rng_sample)
+        power_action = jnp.array([0.001])  # 1 mW, linear units as stored by select_action
+        action = jnp.concatenate([path_action.reshape((1,)).astype(jnp.float32), power_action])
+        obs, new_state, reward, terminal, truncated, info = self.env.step(
+            rng_step, state, action, self.params
+        )
+        # The power element must be logged, not fed to process_path_action
+        self.assertIn("launch_power", info)
+        np.testing.assert_allclose(np.asarray(info["launch_power"]), 0.001, rtol=1e-6)
+        # Common GN-model fields decode from the scalar path element
+        chex.assert_shape(info["path_index"], ())
+        chex.assert_shape(info["slot_index"], ())
+        # Only the RSA-GN state tracks throughput; the RMSA variant must not
+        # attempt to pop the missing "_throughput" key
+        self.assertNotIn("throughput", info)
+        self.assertNotIn("_throughput", info)
+
+
 def rmsa_gn_model_enforce_band_gaps_test_setup():
     key = jax.random.PRNGKey(3)
     if "rmsa_gn_model_band_gaps" in _gn_cache:

--- a/xlron/environments/wrappers.py
+++ b/xlron/environments/wrappers.py
@@ -13,10 +13,10 @@ from jax import Array, tree_util
 
 from xlron import dtype_config
 from xlron.environments.dataclasses import (
+    GNModelEnvParams,
     LogEnvState,
     RSAEnvParams,
     RSAEnvState,
-    RSAGNModelEnvParams,
 )
 from xlron.environments.env_funcs import (
     get_path_indices,
@@ -111,19 +111,21 @@ class LogWrapper(GymnaxWrapper):
         info["fragmentation"] = log_state.fragmentation
         info["terminal"] = terminal
         info["truncated"] = truncated
-        # First check if we're dealing with RSAGNModelEnvParams
-        is_gn_params = isinstance(params, RSAGNModelEnvParams)
+        # First check if we're dealing with a GN-model env (RSA or RMSA variant; both
+        # params classes derive from GNModelEnvParams)
+        is_gn_params = isinstance(params, GNModelEnvParams)
 
-        # For RSA params, unpack the action. The action is [path_slot_action, launch_power]
-        # when the RL agent controls launch power, or a bare path_slot_action otherwise
-        # (e.g. GNN path policy with fixed launch power) - mirror process_action's handling.
+        # For GN-model params, unpack the action. The action is [path_slot_action,
+        # launch_power] when the RL agent controls launch power, or a bare
+        # path_slot_action otherwise (e.g. GNN path policy with fixed launch power)
+        # - mirror process_action's handling.
         if is_gn_params:
             action = jnp.atleast_1d(action)
             power_action = (
                 action[1]
                 if action.shape[0] > 1
                 else jnp.asarray(
-                    cast(RSAGNModelEnvParams, params).default_launch_power,
+                    cast(GNModelEnvParams, params).default_launch_power,
                     dtype=dtype_config.LARGE_FLOAT_DTYPE,
                 )
             )
@@ -152,8 +154,9 @@ class LogWrapper(GymnaxWrapper):
             info["dest"] = dest
             info["data_rate"] = dr_request
 
-            # RSA-specific throughput info (use pre-reset value from step_env)
-            if is_gn_params:
+            # RSA-GN-specific throughput info (use pre-reset value from step_env; only
+            # the RSA-GN state tracks throughput, so the RMSA variant has no "_throughput")
+            if is_gn_params and "_throughput" in info:
                 info["throughput"] = info.pop("_throughput")
 
             # Logging-specific info

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -205,7 +205,9 @@ def _env_step(
 
     # DEBUG LOGGING FOR OPTICAL NETWORKS
     if config.DEBUG:
-        path_action = action[0][0] if config.env_type.lower() == "rsa_gn_model" else action
+        # GN-model envs with RL launch power emit [path_slot_action, power] actions
+        is_gn_rl_power = "gn_model" in config.env_type.lower() and config.launch_power_type == "rl"
+        path_action = action[0] if is_gn_rl_power else action
         path_index, slot_index = process_path_action(env_state.env_state, env_params, path_action)
         path = env_params.path_link_array[path_index]
 
@@ -245,12 +247,14 @@ def _env_step(
                 env_state.env_state.node_capacity_array,
                 ordered=config.ORDERED,
             )
-        elif config.env_type.lower() == "rsa_gn_model":
-            jax.debug.print(
-                "modulation_format_index_array {}",
-                get_path_links(env_state.env_state.modulation_format_index_array),
-                ordered=config.ORDERED,
-            )
+        elif "gn_model" in config.env_type.lower():
+            # Only the RMSA-GN state carries a modulation format array
+            if hasattr(env_state.env_state, "modulation_format_index_array"):
+                jax.debug.print(
+                    "modulation_format_index_array {}",
+                    get_path_links(env_state.env_state.modulation_format_index_array),
+                    ordered=config.ORDERED,
+                )
             jax.debug.print(
                 "channel_centre_bw_array {}",
                 get_path_links(env_state.env_state.channel_centre_bw_array),
@@ -586,7 +590,9 @@ def _loss_fn(
             jax.debug.print("power_log_prob {}", power_log_prob, ordered=config.ORDERED)
             jax.debug.print("path_entropy {}", path_entropy, ordered=config.ORDERED)
             jax.debug.print("power_entropy {}", power_entropy, ordered=config.ORDERED)
-            jax.debug.print("power logits {}", power_dist._logits, ordered=config.ORDERED)
+            if config.discrete_launch_power:
+                # Continuous mode uses a Beta distribution, which has no logits
+                jax.debug.print("power logits {}", power_dist._logits, ordered=config.ORDERED)
             jax.debug.print("log_prob {}", log_prob, ordered=config.ORDERED)
             jax.debug.print("entropy {}", entropy, ordered=config.ORDERED)
     else:

--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -529,8 +529,9 @@ def _loss_fn(
         log_prob = log_prob_source + log_prob_path + log_prob_dest
         entropy = pi_source.entropy() + pi_path.entropy() + pi_dest.entropy()
 
-    elif config.env_type.lower() == "rsa_gn_model" and config.launch_power_type == "rl":
-        # RSA with power control
+    elif "gn_model" in config.env_type.lower() and config.launch_power_type == "rl":
+        # RSA/RMSA with power control (RMSA shares the flat path-slot action decode:
+        # the modulation format is derived from the env's mod_format_mask, not the action)
         path_actions = traj_batch.action[..., 0]
         power_actions = traj_batch.action[..., 1]
         path_dist, power_dist = pi
@@ -702,7 +703,7 @@ def _loss_fn(
             current_valid_mass = jnp.sum(
                 current_probs * vone_batch.action_mask_p.astype(jnp.float32), axis=-1
             )
-        elif config.env_type.lower() == "rsa_gn_model" and config.launch_power_type == "rl":
+        elif "gn_model" in config.env_type.lower() and config.launch_power_type == "rl":
             current_probs = jax.nn.softmax(pi[0]._logits, axis=-1)
             current_valid_mass = jnp.sum(current_probs * traj_batch.action_mask, axis=-1)
         elif config.OFF_POLICY_IAM:

--- a/xlron/train/train_smoke_test.py
+++ b/xlron/train/train_smoke_test.py
@@ -2,9 +2,12 @@
 
 Regression cover for the launch_power_type="rl" training path, which rotted invisibly
 because nothing exercised the full train pipeline (init_network -> warmup/select_action
--> rollout -> _loss_fn) with a GN-model env. Each test runs the real entry point in a
-subprocess with a tiny config; a clean exit is the assertion. Marked slow (~20s each,
-dominated by XLA compilation): deselect with `pytest -m "not slow"`.
+-> rollout -> _loss_fn) with a GN-model env. Covers both GN-model env variants:
+rmsa_gn_model shares the flat path-slot action decode with rsa_gn_model but previously
+crashed in _loss_fn because ppo.py gated the (path, power) tuple handling on the exact
+env_type "rsa_gn_model". Each test runs the real entry point in a subprocess with a tiny
+config; a clean exit is the assertion. Marked slow (~20s each, dominated by XLA
+compilation): deselect with `pytest -m "not slow"`.
 """
 
 import os
@@ -16,7 +19,6 @@ import pytest
 BASE_ARGS = [
     "-m",
     "xlron.train.train",
-    "--env_type=rsa_gn_model",
     "--topology_name=nsfnet_deeprmsa_directed",
     "--link_resources=10",
     "--k=4",
@@ -32,10 +34,10 @@ BASE_ARGS = [
 ]
 
 
-def _run_train(extra_args=()):
+def _run_train(env_type, extra_args=()):
     env = dict(os.environ, JAX_PLATFORMS="cpu")
     result = subprocess.run(
-        [sys.executable, *BASE_ARGS, *extra_args],
+        [sys.executable, *BASE_ARGS, f"--env_type={env_type}", *extra_args],
         capture_output=True,
         text=True,
         timeout=600,
@@ -50,12 +52,14 @@ def _run_train(extra_args=()):
 
 
 @pytest.mark.slow
-def test_launch_power_rl_training_smoke_continuous():
+@pytest.mark.parametrize("env_type", ["rsa_gn_model", "rmsa_gn_model"])
+def test_launch_power_rl_training_smoke_continuous(env_type):
     """MLP power-only policy with the continuous (Beta) power head (the default)."""
-    _run_train()
+    _run_train(env_type)
 
 
 @pytest.mark.slow
-def test_launch_power_rl_training_smoke_discrete():
+@pytest.mark.parametrize("env_type", ["rsa_gn_model", "rmsa_gn_model"])
+def test_launch_power_rl_training_smoke_discrete(env_type):
     """MLP power-only policy with the discrete (Categorical) power head."""
-    _run_train(["--discrete_launch_power"])
+    _run_train(env_type, ["--discrete_launch_power"])


### PR DESCRIPTION
## What

Extends the `launch_power_type=rl` repair (PRs #44/#47) from `rsa_gn_model` to `rmsa_gn_model`. Before this PR, `--env_type=rmsa_gn_model --launch_power_type=rl` crashed at compile time in `_loss_fn` with `AttributeError: 'tuple' object has no attribute '_logits'`, because `xlron/train/ppo.py` gated the (path, power) tuple-action handling on `env_type == "rsa_gn_model"` exactly, while `ActorCriticGNN`/`LaunchPowerActorCriticMLP` already return the `(path_dist, power_dist)` tuple for `RMSAGNModelEnvParams` (since #47).

### Changes

**`xlron/train/ppo.py`** (commit 1)
- `_loss_fn` tuple-action branch and `VALID_MASS_LOSS_COEF` branch: gate changed from `env_type.lower() == "rsa_gn_model"` to `"gn_model" in env_type.lower()` (+ `launch_power_type == "rl"`, unchanged), matching the pattern `select_action` and the warmup in `train_utils.py` already use.
- The flat path-slot decode in the loss (`path = action // ceil(link_resources / aggregate_slots)`) is valid for RMSA as-is: `RMSAGNModelEnv` inherits `RSAEnv`'s action space, and the modulation format is derived from the env's `mod_format_mask` inside `RSAEnv.process_action` — it is not an action dimension. Verified against `process_path_action` / `process_action` before reusing the rsa semantics.

**`xlron/environments/wrappers.py`** (commit 1)
- `LogWrapper.step`: `is_gn_params` now tests `isinstance(params, GNModelEnvParams)` (common base) instead of `RSAGNModelEnvParams`. `RMSAGNModelEnvParams` is a *sibling* of `RSAGNModelEnvParams`, not a subclass, so the rmsa variant previously skipped the `[path_slot_action, launch_power]` unpacking: `info["launch_power"]` was never logged, and with `--log_actions` the raw 2-element action leaked into `process_path_action`, producing vector-shaped (corrupt) `path_index`/`slot_index` info fields.
- The `info["throughput"] = info.pop("_throughput")` stays RSA-GN-only via a `"_throughput" in info` guard: only `RSAGNModelEnvState` tracks throughput (`rsa.py` stashes `_throughput` behind `hasattr(state, "throughput")`), so popping unconditionally for rmsa would KeyError.

**`xlron/train/ppo.py` DEBUG fixes** (commit 2) — three pre-existing `--DEBUG`-only crashes surfaced while verifying:
- `_env_step` decoded the debug path action as `action[0][0]`, which IndexErrors on the `(2,)`-shaped tuple action (broken for rsa_gn_model + rl too). Now `action[0]`, gated on GN-model + `launch_power_type == "rl"` (with fixed power the action is a bare scalar).
- The GN-model state debug block printed `modulation_format_index_array` for `rsa_gn_model` exactly — but only the RMSA-GN state carries that field (AttributeError on the RSA variant). Gate broadened to both variants with a `hasattr` guard.
- The `_loss_fn` debug block printed `power_dist._logits`, which only exists for the discrete (Categorical) power head; the continuous head is a Beta distribution. Now printed only when `discrete_launch_power`.

## Tests added

- `xlron/train/train_smoke_test.py`: both launch-power smoke tests parametrized over `env_type in {rsa_gn_model, rmsa_gn_model}` × {continuous Beta, discrete Categorical} power heads (4 slow subprocess cases; the rmsa cases fail on main with the `_logits` AttributeError).
- `xlron/environments/gn_model/gn_model_test.py::RMSAGNModelLogWrapperTest`: steps the LogWrapper-wrapped `rmsa_gn_model` + rl env with a `[path, power]` action and asserts `info["launch_power"]` is logged with the correct value, `path_index`/`slot_index` are scalars, and no throughput key appears. Verified to fail on pre-fix `wrappers.py` and pass after.

## Verification

- Assignment E2E command passes exactly as given (no additional GN flags were needed), plus the `--discrete_launch_power` variant — both exit 0.
- `--DEBUG` E2E runs of both variants: the training loop completes and prints all GN state arrays (the run still ends with a **pre-existing, env-agnostic** failure: `--DEBUG` enables `jax_debug_nans`, which trips on the intentional NaN padding in `get_episode_end_mean_std_iqr` (`train_utils.py:1749`) during *post-run* metric processing — out of scope here, affects every env type).
- Suites: `train_smoke_test.py` 4 passed; `ppo_test.py` + `train_utils_test.py` 35 passed; `gn_model_test.py` 67 passed / 6 skipped; `rsa/rsa_test.py` 361 passed / 80 skipped (CPU JAX).

## Behavior changes

- `rmsa_gn_model + launch_power_type=rl` now trains (previously crashed at compile time).
- `LogWrapper` now logs `info["launch_power"]` for `rmsa_gn_model`, and computes the common GN info fields (`path_index`, `slot_index`, `source`, `dest`, `data_rate`) for rmsa steps even without `--log_actions`, matching existing rsa_gn_model behavior (`process_metrics` tolerates the extra keys via its KeyError-skip loop).
- With `--log_actions` on rmsa + rl power, logged path/slot indices are now decoded from the scalar path element rather than the raw 2-element action.
- `--DEBUG` no longer crashes inside the training loop for GN-model envs (either variant, either power head).
- No behavior change for non-GN envs, vone, or GN-model envs with fixed launch power.

---
*Follow-up batch (user-selected items from the July 2026 review). Each adversarially reviewed; full suite green per branch.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)