### PR TITLE
Fix prioritized-replay resampling crash for unvmapped NUM_ENVS=1 rollouts

### DIFF
--- a/xlron/train/ppo.py
+++ b/xlron/train/ppo.py
@@ -90,12 +90,19 @@ def _sample_prioritized_batch(
             importance_weights = importance_weights / jnp.maximum(jnp.max(importance_weights), 1e-8)
             importance_weights = importance_weights.astype(dtype_config.LARGE_FLOAT_DTYPE)
 
-            batch = jax.tree.map(
-                lambda x: jnp.take(x.reshape((-1, *x.shape[2:])), sampled_indices, axis=0).reshape(
-                    x.shape
-                ),
-                batch,
-            )
+            if config.NUM_ENVS > 1:
+                # Leaves are (ROLLOUT_LENGTH, NUM_ENVS, ...): flatten the env axis for the
+                # per-sample take, then restore the original layout.
+                batch = jax.tree.map(
+                    lambda x: jnp.take(
+                        x.reshape((-1, *x.shape[2:])), sampled_indices, axis=0
+                    ).reshape(x.shape),
+                    batch,
+                )
+            else:
+                # Unvmapped NUM_ENVS=1 rollout: leaves are (ROLLOUT_LENGTH, ...) with no env
+                # axis, so axis 0 is already the flat sample axis.
+                batch = jax.tree.map(lambda x: jnp.take(x, sampled_indices, axis=0), batch)
 
         else:
             # If using RNN we can only prioritize entire trajectories
@@ -109,13 +116,23 @@ def _sample_prioritized_batch(
                 config.NUM_ENVS * jnp.take(priority_probs, sampled_indices), -beta
             )
             trajectory_weights = trajectory_weights / jnp.maximum(jnp.max(trajectory_weights), 1e-8)
-            importance_weights = jnp.tile(
-                trajectory_weights.astype(dtype_config.LARGE_FLOAT_DTYPE),
-                (config.ROLLOUT_LENGTH, 1),
-            )
+            if config.NUM_ENVS > 1:
+                importance_weights = jnp.tile(
+                    trajectory_weights.astype(dtype_config.LARGE_FLOAT_DTYPE),
+                    (config.ROLLOUT_LENGTH, 1),
+                )
 
-            # Create a prioritized batch
-            batch = jax.tree.map(lambda x: jnp.take(x, sampled_indices, axis=1), batch)
+                # Create a prioritized batch
+                batch = jax.tree.map(lambda x: jnp.take(x, sampled_indices, axis=1), batch)
+            else:
+                # Unvmapped NUM_ENVS=1 rollout: leaves are (ROLLOUT_LENGTH, ...) with no env
+                # axis to take along, and sampling one trajectory out of one is the identity
+                # (sampled_indices == [0]), so the batch is unchanged. Broadcast the single
+                # trajectory's weight per-sample as (ROLLOUT_LENGTH,) to match the batch axis.
+                importance_weights = jnp.tile(
+                    trajectory_weights.astype(dtype_config.LARGE_FLOAT_DTYPE),
+                    config.ROLLOUT_LENGTH,
+                )
 
     batch_with_weights = (batch, importance_weights)
 

--- a/xlron/train/ppo_test.py
+++ b/xlron/train/ppo_test.py
@@ -29,6 +29,7 @@ from xlron.train.ppo import (
     _recompute_vtrace_advantages,
     _sample_prioritized_batch,
     compute_sample_priority_weights,
+    compute_trajectory_priority_weights,
 )
 from xlron.train.train_utils import TrainState
 
@@ -404,6 +405,134 @@ class VTracePrioritizedReplayTest(chex.TestCase):
         perturbed_info = (flat[0], flat[1] + flat[1] ** 2, flat[2], jnp.ones((n,)))
         (loss_p, _), _ = _loss_fn(drifted, train_state, perturbed_info, config_vtrace)
         self.assertGreater(abs(float(loss_p - loss_v)), 1e-6)
+
+
+class SingleEnvPrioritizedReplayTest(chex.TestCase):
+    """Regression tests for ``_sample_prioritized_batch`` with the unvmapped NUM_ENVS=1 rollout.
+
+    With NUM_ENVS=1 the rollout is not vmapped, so transition leaves are
+    (ROLLOUT_LENGTH, ...) with no env axis. The per-sample resampling assumed a
+    (T, E, ...) layout: ``x.reshape((-1, *x.shape[2:]))`` flattened a real feature
+    dimension (e.g. an obs leaf (32, 4403) -> (140896,)) and the reshape back to
+    x.shape crashed with "cannot reshape array of shape (32,) (size 32) into shape
+    (32, 4403)". The trajectory (RNN) branch likewise took along a nonexistent env
+    axis 1 and tiled importance weights to (T, 1) instead of (T,).
+    """
+
+    T, OBS_DIM, N_ACTIONS = 8, 6, 5
+
+    def _config(self, **overrides):
+        base = dict(
+            env_type="rwa",
+            USE_GNN=False,
+            USE_TRANSFORMER=False,
+            USE_RNN=False,
+            OFF_POLICY_IAM=False,
+            LOGR_CLIP=10.0,
+            ROLLOUT_LENGTH=self.T,
+            NUM_ENVS=1,
+            NUM_MINIBATCHES=2,
+            MINIBATCH_SIZE=self.T // 2,
+            NUM_LEARNERS=1,
+            GAMMA=0.99,
+            GAE_LAMBDA=0.9,
+            REWARD_CENTERING=False,
+            RHO_CLIP=1.0,
+            C_CLIP=1.0,
+            PRIO_ALPHA=0.6,
+            PRIO_BETA0=0.4,
+            PROFILE=False,
+            DEBUG=False,
+            DEBUG_LOSS=False,
+            ENHANCED_LOGGING=False,
+            IAM_GATING=False,
+            IAM_DAMPING=False,
+            ADV_CLIP=10.0,
+            CLIP_EPS=0.2,
+            VF_COEF=0.5,
+            VALID_MASS_LOSS_COEF=0.0,
+        )
+        base.update(overrides)
+        return Box(base)
+
+    def _rollout(self, seed=0):
+        """Synthetic ordered NUM_ENVS=1 rollout: leaves are (T, ...) with no env axis."""
+        t, obs_dim, n_actions = self.T, self.OBS_DIM, self.N_ACTIONS
+        kmodel, kobs, kact, krew, klast = jax.random.split(jax.random.PRNGKey(seed), 5)
+        model = ActorCriticMLP(n_actions, obs_dim, num_layers=1, num_units=16, key=kmodel)
+        train_state = TrainState.create(model, optax.adam(1e-3))
+        obs = jax.random.normal(kobs, (t, obs_dim))
+        pi, value = jax.vmap(model)(obs)
+        action = pi.sample(seed=kact)
+        # All-ones mask: the masked behaviour policy equals the unmasked policy
+        log_prob = pi.log_prob(action)
+        traj = RSATransition(
+            terminal=jnp.zeros((t,), dtype=bool),
+            truncated=jnp.zeros((t,), dtype=bool),
+            action=action.reshape(t),
+            value=value.reshape(t),
+            reward=jax.random.normal(krew, (t,)),
+            log_prob=log_prob.reshape(t),
+            obs=(obs,),
+            # Unique per-sample id rides through resampling to identify each transition
+            info={"idx": jnp.arange(t, dtype=jnp.float32)},
+            action_mask=jnp.ones((t, n_actions)),
+            valid_mass=jnp.ones((t,)),
+        )
+        last_val = jax.random.normal(klast, ())
+        return model, train_state, traj, last_val
+
+    def test_per_sample_resampling_carries_matching_rows(self):
+        """NUM_ENVS=1 + PRIO_ALPHA>0 (+ PRIO_BETA0 != 1) must not crash, and every
+        resampled sample must carry its own obs row / advantage / target."""
+        _, train_state, traj, last_val = self._rollout()
+        config = self._config()
+        adv, targets = _recompute_vtrace_advantages(train_state, traj, last_val, config)
+        self.assertEqual(adv.shape, (self.T,))
+        priorities = compute_sample_priority_weights(adv, jnp.array(config.PRIO_ALPHA))
+        for seed in (0, 1):
+            minibatches, weights = _sample_prioritized_batch(
+                (traj, adv, targets),
+                priorities,
+                jnp.array(config.PRIO_BETA0),
+                jax.random.PRNGKey(seed),
+                config,
+            )
+            mb_traj, mb_adv, mb_targets = minibatches
+            idx = mb_traj.info["idx"].reshape(-1).astype(jnp.int32)
+            # Resampling with replacement must permute (traj, adv, targets) consistently
+            chex.assert_trees_all_close(mb_adv.reshape(-1), adv[idx], atol=1e-6)
+            chex.assert_trees_all_close(mb_targets.reshape(-1), targets[idx], atol=1e-6)
+            # Feature-bearing leaves (the crash case) keep whole per-sample rows intact
+            mb_obs = mb_traj.obs[0].reshape(-1, self.OBS_DIM)
+            chex.assert_trees_all_close(mb_obs, traj.obs[0][idx], atol=1e-6)
+            # PER importance weights are per-sample and max-normalized
+            self.assertEqual(weights.shape, (config.NUM_MINIBATCHES, config.MINIBATCH_SIZE))
+            self.assertLessEqual(float(weights.max()), 1.0 + 1e-6)
+
+    def test_trajectory_branch_single_env_identity(self):
+        """USE_RNN trajectory-level sampling with a single env: sampling one trajectory
+        out of one is the identity, with unit importance weights of shape (T,)."""
+        _, train_state, traj, last_val = self._rollout()
+        config = self._config(USE_RNN=True)
+        adv, targets = _recompute_vtrace_advantages(train_state, traj, last_val, config)
+        priorities = compute_trajectory_priority_weights(adv, jnp.array(config.PRIO_ALPHA))
+        minibatches, weights = _sample_prioritized_batch(
+            (traj, adv, targets),
+            priorities,
+            jnp.array(config.PRIO_BETA0),
+            jax.random.PRNGKey(0),
+            config,
+        )
+        mb_traj, mb_adv, _ = minibatches
+        # No shuffle with RNN and identity sampling: original temporal order is preserved
+        chex.assert_trees_all_close(mb_adv.reshape(-1), adv, atol=1e-6)
+        chex.assert_trees_all_close(
+            mb_traj.obs[0].reshape(-1, self.OBS_DIM), traj.obs[0], atol=1e-6
+        )
+        # The single trajectory has probability 1, so its PER weight is exactly 1
+        self.assertEqual(weights.shape, (config.NUM_MINIBATCHES, config.MINIBATCH_SIZE))
+        chex.assert_trees_all_close(weights, jnp.ones_like(weights), atol=1e-6)
 
 
 class _Traj(NamedTuple):


### PR DESCRIPTION
## Problem

With `NUM_ENVS=1` the rollout is not vmapped, so transition leaves have shape `(ROLLOUT_LENGTH, ...)` with no env axis. `_sample_prioritized_batch`'s per-sample prioritized-resampling branch (taken when `PRIO_ALPHA > 0` and `PRIO_BETA0 != 1.0` without an RNN) assumed a `(T, E, ...)` layout:

```python
jnp.take(x.reshape((-1, *x.shape[2:])), sampled_indices, axis=0).reshape(x.shape)
```

For a `NUM_ENVS=1` obs leaf of shape `(32, 4403)`, `x.shape[2:]` drops the real feature dimension: the leaf is flattened to `(140896,)`, 32 indices are taken, and the reshape back crashes:

```
TypeError: cannot reshape array of shape (32,) (size 32) into shape (32, 4403) (size 140896)
```

Repro: `uv run python -m xlron.train.train --env_type=rmsa --topology_name=nsfnet_deeprmsa_directed --link_resources=100 --continuous_operation --ENV_WARMUP_STEPS=50 --truncate_holding_time --k=5 --ROLLOUT_LENGTH=32 --TOTAL_TIMESTEPS=128 --STEPS_PER_INCREMENT=64 --NUM_ENVS=1 --UPDATE_EPOCHS=2 --NUM_MINIBATCHES=2 --PRIO_ALPHA=0.6 --PRIO_BETA0=0.4`

The trajectory (`USE_RNN`) branch had the same layout assumption: `jnp.take(x, sampled_indices, axis=1)` raises on leaves with no env axis, and its `(ROLLOUT_LENGTH, 1)`-tiled importance weights would have broadcast wrongly against the `(T,)` batch axis.

## Fix

Branch on `config.NUM_ENVS` (static python config) at trace time in `_sample_prioritized_batch`:

- **Per-sample branch, `NUM_ENVS=1`**: leaves are already flat along the sample axis, so take rows directly with `jnp.take(x, sampled_indices, axis=0)`.
- **Trajectory branch, `NUM_ENVS=1`**: sampling one trajectory out of one is the identity (`sampled_indices == [0]`), so the batch is left untouched and the single trajectory's weight is broadcast per-sample as shape `(ROLLOUT_LENGTH,)`.
- The `NUM_ENVS > 1` paths keep the exact same ops in the same order (only lambda line-wrapping changed).

Audited every `(T, E, ...)` flatten/reshape site in `ppo.py`: `_recompute_vtrace_advantages` already guards its flatten with the same `NUM_ENVS > 1` check (unchanged, kept consistent); the priority-weight helpers, uniform-weights path, `batch_with_weights` flatten, and minibatch split are all layout-correct for `NUM_ENVS=1`.

## Tests

- New `SingleEnvPrioritizedReplayTest` in `xlron/train/ppo_test.py` (synthetic no-env-axis rollout, per-sample `idx` identity-tracking following the `VTracePrioritizedReplayTest` pattern):
  - `test_per_sample_resampling_carries_matching_rows`: `NUM_ENVS=1` + `PRIO_ALPHA>0` runs without error; every resampled sample carries its own obs row / advantage / target; PER weights are per-sample and max-normalized.
  - `test_trajectory_branch_single_env_identity`: RNN branch is the identity with unit `(T,)` weights.
  - Both fail on the unfixed code (reshape `TypeError` / axis-1 `ValueError`).
- `xlron/train/ppo_test.py`: 19 passed.
- E2E: the repro command above completes cleanly, and the `NUM_ENVS=2` variant completes cleanly (no regression).

## Behavior changes

None for `NUM_ENVS>1` (identical ops, identical order). `NUM_ENVS=1` with prioritized replay (`PRIO_ALPHA>0`, `PRIO_BETA0 != 1.0`) previously crashed at the first PPO update; it now trains.

---
*User-reported bug. Adversarially reviewed; full suite green (2159 passed).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)