### PR TITLE
Fix episodic load sweep: preserve swept traffic params across episode auto-resets

### DIFF
--- a/docs/heuristic_evaluation.md
+++ b/docs/heuristic_evaluation.md
@@ -120,7 +120,7 @@ The offered traffic load in Erlangs. This is the primary traffic parameter — i
 
 When all three are set, the script sweeps loads from `min_load` to `max_load` (inclusive) in steps of `step_load`. The environment is compiled once and reused across all loads without JIT recompilation, which is significantly faster than running separate processes per load. Each load produces its own JSONL summary line. `--load` should be set to the maximum load in the sweep range for initial compilation.
 
-Each swept load re-equilibrates before measurement: the warmup is re-run for `ENV_WARMUP_STEPS` at that load's arrival rate (a single extra compilation, reused across all loads) and the metric counters are zeroed afterwards, so each load's reported metrics reflect its own steady state rather than the network occupancy inherited from the initial `--load` warmup. This adds `ENV_WARMUP_STEPS` un-measured steps per swept load. Example:
+Each swept load re-equilibrates before measurement: the warmup is re-run for `ENV_WARMUP_STEPS` at that load's arrival rate (a single extra compilation, reused across all loads) and the metric counters are zeroed afterwards, so each load's reported metrics reflect its own steady state rather than the network occupancy inherited from the initial `--load` warmup. This adds `ENV_WARMUP_STEPS` un-measured steps per swept load. The sweep is also correct in episodic (non-continuous) mode: episode auto-resets preserve the swept arrival rate rather than reverting to the compile-time `--load` value. Example:
 
 ```bash
 python -m xlron.train.train \

--- a/xlron/environments/rsa/rsa.py
+++ b/xlron/environments/rsa/rsa.py
@@ -1106,9 +1106,16 @@ class RSAEnv(environment.Environment):
         Generates new random traffic matrix if random_traffic is True, otherwise uses the provided traffic matrix.
         Generates new request.
 
+        When a pre-reset state is provided (the auto-reset path in step threads it
+        through), traffic parameters that can be modified at runtime — arrival_rate
+        and mean_service_holding_time, e.g. patched by the load sweep in train.py —
+        are carried over instead of reverting to the construction-time values baked
+        into initial_state.
+
         Args:
             key: PRNG key
             params: Environment parameters
+            state: Optional pre-reset environment state
 
         Returns:
             obs: Observation
@@ -1121,6 +1128,7 @@ class RSAEnv(environment.Environment):
         # and then cycle select from them randomly and replace the top-level params with the selected one.
         # Then need to init() the env again in order to update the state using the params
         #    raise NotImplementedError
+        prev_state = state
         if params.random_traffic:
             key, key_traffic = jax.random.split(key)
             state = self.initial_state.replace(
@@ -1128,6 +1136,11 @@ class RSAEnv(environment.Environment):
             )
         else:
             state = self.initial_state
+        if prev_state is not None:
+            state = state.replace(
+                arrival_rate=prev_state.arrival_rate,
+                mean_service_holding_time=prev_state.mean_service_holding_time,
+            )
         state = generate_request_rsa(key, state, params)
         return self.get_obs(state, params), state
 

--- a/xlron/environments/rsa/rsa_test.py
+++ b/xlron/environments/rsa/rsa_test.py
@@ -892,6 +892,65 @@ class RsaMultibandBandGapTest(chex.TestCase):
         )
 
 
+class RsaResetPreservesTrafficParamsTest(chex.TestCase):
+    """Regression tests for the episodic load-sweep bug: runtime-patched
+    arrival_rate/mean_service_holding_time (as set by the load sweep in
+    train.py) must survive episode auto-resets instead of reverting to the
+    construction-time values baked into initial_state."""
+
+    def setUp(self):
+        super().setUp()
+        # rwa_4node settings are episodic (max_requests=10, no continuous_operation)
+        self.key, self.env, self.obs, self.state, self.params = rwa_4node_test_setup()
+
+    def test_auto_reset_preserves_swept_traffic_params(self):
+        # Patch the live state the way _update_experiment_input_load does
+        patched = self.state.replace(
+            arrival_rate=jnp.full_like(self.state.arrival_rate, 99.0),
+            mean_service_holding_time=jnp.full_like(self.state.mean_service_holding_time, 7.0),
+            # Next step's request generation reaches max_requests -> truncation
+            total_requests=jnp.array(
+                self.params.max_requests - 1, dtype=self.state.total_requests.dtype
+            ),
+        )
+        _, new_state, _, terminal, truncated, _ = self.env.step(
+            self.key, patched, jnp.array(0), self.params
+        )
+        self.assertTrue(bool(truncated | terminal))
+        chex.assert_trees_all_close(
+            new_state.arrival_rate, jnp.full_like(new_state.arrival_rate, 99.0)
+        )
+        chex.assert_trees_all_close(
+            new_state.mean_service_holding_time,
+            jnp.full_like(new_state.mean_service_holding_time, 7.0),
+        )
+
+    def test_fresh_reset_uses_params_values(self):
+        _, state = self.env.reset(self.key, self.params)
+        chex.assert_trees_all_close(
+            state.arrival_rate,
+            jnp.full_like(state.arrival_rate, self.params.arrival_rate),
+        )
+        chex.assert_trees_all_close(
+            state.mean_service_holding_time,
+            jnp.full_like(state.mean_service_holding_time, self.params.mean_service_holding_time),
+        )
+
+    def test_reset_env_with_state_preserves_traffic_params(self):
+        patched = self.state.replace(
+            arrival_rate=jnp.full_like(self.state.arrival_rate, 42.5),
+            mean_service_holding_time=jnp.full_like(self.state.mean_service_holding_time, 3.0),
+        )
+        _, state = self.env.reset_env(self.key, self.params, patched)
+        chex.assert_trees_all_close(state.arrival_rate, jnp.full_like(state.arrival_rate, 42.5))
+        chex.assert_trees_all_close(
+            state.mean_service_holding_time,
+            jnp.full_like(state.mean_service_holding_time, 3.0),
+        )
+        # Everything else resets: spectrum empty, counters back to start
+        chex.assert_trees_all_close(state.link_slot_array, jnp.zeros_like(state.link_slot_array))
+
+
 if __name__ == "__main__":
     jax.config.update("jax_numpy_rank_promotion", "raise")
     absltest.main()

--- a/xlron/environments/vone/vone.py
+++ b/xlron/environments/vone/vone.py
@@ -108,7 +108,7 @@ class VONEEnv(environment.Environment):
             key, state, action, params
         )
         done = terminal | truncated
-        obs_re, state_re = self.reset_env(key_reset, params)
+        obs_re, state_re = self.reset_env(key_reset, params, state)
         # Auto-reset environment based on termination
         state = jax.tree.map(lambda x, y: jnp.where(done, x, y), state_re, state_st)
         obs = jax.lax.select(done, obs_re, obs_st)
@@ -229,8 +229,20 @@ class VONEEnv(environment.Environment):
         params: VONEEnvParams,
         state: Optional[VONEEnvState] = None,
     ) -> Tuple[Array, VONEEnvState]:
-        """Environment-specific reset."""
+        """Environment-specific reset.
+
+        When a pre-reset state is provided (the auto-reset path in step threads it
+        through), runtime-modifiable traffic parameters (arrival_rate,
+        mean_service_holding_time — e.g. patched by the load sweep in train.py)
+        are carried over instead of reverting to the construction-time values.
+        """
+        prev_state = state
         state = self.initial_state
+        if prev_state is not None:
+            state = state.replace(
+                arrival_rate=prev_state.arrival_rate,
+                mean_service_holding_time=prev_state.mean_service_holding_time,
+            )
         state = generate_vone_request(key, state, params)
         return self.get_obs(state), state
 

--- a/xlron/environments/vone/vone_test.py
+++ b/xlron/environments/vone/vone_test.py
@@ -1661,6 +1661,40 @@ class VoneRLSmokeTest(chex.TestCase):
             self.assertTrue(bool(jnp.all(jnp.isfinite(leaf))))
 
 
+class VoneResetPreservesTrafficParamsTest(chex.TestCase):
+    """Regression test: reset_env must carry over runtime-patched
+    arrival_rate/mean_service_holding_time from a provided pre-reset state
+    (episodic load-sweep support) instead of reverting to initial_state values."""
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = vone_4node_test_setup()
+
+    def test_reset_env_with_state_preserves_traffic_params(self):
+        patched = self.state.replace(
+            arrival_rate=jnp.full_like(jnp.asarray(self.state.arrival_rate), 99.0),
+            mean_service_holding_time=jnp.full_like(
+                jnp.asarray(self.state.mean_service_holding_time), 7.0
+            ),
+        )
+        _, state = self.env.reset_env(self.key, self.params, patched)
+        chex.assert_trees_all_close(
+            jnp.asarray(state.arrival_rate),
+            jnp.full_like(jnp.asarray(state.arrival_rate), 99.0),
+        )
+        chex.assert_trees_all_close(
+            jnp.asarray(state.mean_service_holding_time),
+            jnp.full_like(jnp.asarray(state.mean_service_holding_time), 7.0),
+        )
+
+    def test_reset_env_without_state_uses_params_values(self):
+        _, state = self.env.reset_env(self.key, self.params)
+        chex.assert_trees_all_close(
+            jnp.asarray(state.arrival_rate),
+            jnp.full_like(jnp.asarray(state.arrival_rate), self.params.arrival_rate),
+        )
+
+
 if __name__ == "__main__":
     jax.config.update("jax_numpy_rank_promotion", "raise")
     absltest.main()


### PR DESCRIPTION
## Bug

The load sweep (`--min_load`/`--max_load`/`--step_load`) patches `arrival_rate` and `mean_service_holding_time` in the live env state, but `reset_env` restored `self.initial_state`, whose values are baked in at env construction from the compile-time `--load`. In **episodic** mode (no `--continuous_operation`), every episode auto-reset therefore reverted the traffic load to the compile-time value — all episodes after the first ran at the wrong load.

**Observed symptom:** a 9-point episodic load sweep on `usa100_directed` (550–750 Erlang) produced a *flat* blocking-probability curve (~1e-2 at every point). Continuous-operation sweeps are unaffected (no resets occur).

## Fix

- `RSAEnv.reset_env` now carries `arrival_rate` and `mean_service_holding_time` over from the pre-reset state, which the auto-reset path in `step` already threads through. Covers all RSA-family envs (rsa/rmsa/deeprmsa/rwa_lr/GN-model), which inherit this reset.
- `VONEEnv.step`/`reset`/`reset_env` now thread the pre-reset state the same way and apply the same preservation.
- Fresh resets (no pre-reset state) keep the existing behaviour: values come from params.

## Validation

Episodic 3-point sweep (NSFNET DeepRMSA settings, `ksp_ff`, `max_requests=1000`) after the fix — blocking now varies with load as expected:

| Load (E) | Service BP |
|---|---|
| 150 | 5.0e-05 |
| 200 | 2.6e-03 |
| 250 | 1.8e-02 |

Before the fix all three points reported the 250 E value.

## Tests

- `RsaResetPreservesTrafficParamsTest`: auto-reset via `step` preserves patched values; fresh reset uses params values; direct `reset_env` with a pre-reset state preserves traffic params while resetting spectrum/counters.
- `VoneResetPreservesTrafficParamsTest`: same for VONE.
- Full `rsa_test.py` + `vone_test.py` suites pass (809 passed, 190 skipped).

Docs: load-sweep section notes that sweeps are also correct in episodic mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update — impact on published results.** Forensic reproduction shows this bug affected the arXiv:2605.02075 large-topology eval curves (USA100/TataInd, both `ff_ksp` and Transformer): the eval sweeps were invoked without `--load`, so episodes 2–10 of every sweep point silently ran at the default 250 Erlang (≈zero blocking), diluting every reported blocking probability by ≈10×. Rerunning the paper-era commit with the recovered invocation reproduces the published USA100 550 E value **bit-for-bit** (4.9669051804812625e-05), while a correct single-load run at 550 E gives 6.0e-04. Relative comparisons in the paper (Transformer vs FF-KSP) are unaffected since both curves are diluted by the same factor; absolute blocking values are ~10× understated.


**Corrected curves.** The intended protocol was re-executed on this branch for both topologies and all three policies (ff_ksp, Transformer RL, mscl_ksp; one process per load, fp32). The corrected values are almost exactly 10× the published ones at every point (USA100: 10.0–10.1×; TataInd: 8.6–9.8×), confirming the dilution model quantitatively — the published curve *shapes* and all relative comparisons were preserved (Transformer-vs-FF-KSP relative gains reproduce point-for-point). Corrected data tables are in the PR #46 description supplement.
