### PR TITLE
Add multi-route interfering set to MSCL heuristics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Uses `get_eval_fn` with a loaded model (`--MODEL_PATH`). Runs the trained policy
 ### Heuristics
 - `--EVAL_HEURISTIC` - Run heuristic evaluation instead of RL
 - `--path_heuristic` - Algorithm: `ksp_ff`, `ksp_lf`, `ksp_bf`, `ksp_ef`, `ksp_mu`, `ksp_flf`, `ksp_flef`, `ksp_mscl`, `ff_ksp`, `lf_ksp`, `bf_ksp`, `mu_ksp`, `flf_ksp`, `mscl_ksp`, `kmc_ff`, `kmf_ff`, `kme_ff`, `kca_ff`
-  - Naming: `ksp_*` = try shortest path first; `*_ksp` = search all k paths jointly. Spectrum-assignment families in `heuristics.py`: exact-fit (`ksp_ef`), first-last-fit (`ksp_flf`/`flf_ksp`), first-last-exact-fit (`ksp_flef`), and minimum slot-continuity capacity loss (`ksp_mscl`/`mscl_ksp`, closed-form vectorised lookahead — the strongest and most expensive). Shared helpers: `exact_fit`, `capacity_loss`, `is_large_request` in `heuristics.py`.
+  - Naming: `ksp_*` = try shortest path first; `*_ksp` = search all k paths jointly. Spectrum-assignment families in `heuristics.py`: exact-fit (`ksp_ef`), first-last-fit (`ksp_flf`/`flf_ksp`), first-last-exact-fit (`ksp_flef`), and minimum slot-continuity capacity loss (`ksp_mscl`/`mscl_ksp`, closed-form vectorised lookahead — the strongest and most expensive). `--mscl_interfering_k` sets the MSCL interfering routes per pair (1 = single-route 2013 formulation, default; 0 = all k = multi-route MSCL Sequencial/Combinado of dos Santos UFPE 2021). Shared helpers: `exact_fit`, `capacity_loss`, `is_large_request` in `heuristics.py`.
 
 ### Capacity Bounds (standalone scripts, not through train.py)
 - Cut-sets (`python -m xlron.bounds.cutsets_bounds`): `--max_requests` (requests per trial), `--num_trials`, `--CUTSET_EXHAUSTIVE`, `--CUTSET_TOP_K`

--- a/docs/heuristic_evaluation.md
+++ b/docs/heuristic_evaluation.md
@@ -186,19 +186,33 @@ The heuristic algorithm to use. Available options:
 | `ksp_mu` | **K-Shortest Path, Most-Used.** Try paths in order; prefer slots in the most congested region of the spectrum. |
 | `ksp_flf` | **K-Shortest Path, First-Last-Fit.** On the shortest available path, small requests are allocated first-fit, large requests last-fit, segregating size classes at opposite spectrum ends. (Fadini & Oki, IEEE ICC 2014) |
 | `ksp_flef` | **K-Shortest Path, First-Last-Exact-Fit.** Small requests take the lowest exact-fit block (fallback first-fit); large requests the highest exact-fit block (fallback last-fit). (Chatterjee, Fadini & Oki, JNCA 2016) |
-| `ksp_mscl` | **K-Shortest Path, Minimum Slot-continuity Capacity Loss.** On the shortest available path, allocate the slot minimising capacity loss over the path and interfering routes. (Almeida Jr. et al., Electron. Lett. 2013) |
+| `ksp_mscl` | **K-Shortest Path, Minimum Slot-continuity Capacity Loss.** On the shortest available path, allocate the slot minimising capacity loss over the path and interfering routes (`--mscl_interfering_k` routes per pair; with `0` = all k this is MSCL Sequencial of dos Santos, UFPE 2021). (Almeida Jr. et al., Electron. Lett. 2013) |
 | `ff_ksp` | **First-Fit across K-Shortest Paths.** Search all k paths simultaneously for the globally first available slot. |
 | `lf_ksp` | **Last-Fit across K-Shortest Paths.** Search all k paths for the globally last available slot. |
 | `bf_ksp` | **Best-Fit across K-Shortest Paths.** Search all k paths for the globally best-fit slot. |
 | `mu_ksp` | **Most-Used across K-Shortest Paths.** Search all k paths; prefer globally most-used slots. |
 | `flf_ksp` | **First-Last-Fit across K-Shortest Paths.** Small requests take the globally first slot across paths; large requests the globally last. |
-| `mscl_ksp` | **Minimum Slot-continuity Capacity Loss across K-Shortest Paths.** Jointly select the (path, slot) with minimum capacity loss across all k paths. |
+| `mscl_ksp` | **Minimum Slot-continuity Capacity Loss across K-Shortest Paths.** Jointly select the (path, slot) with minimum capacity loss across all k paths (`--mscl_interfering_k` routes per pair; with `0` = all k this is MSCL Combinado of dos Santos, UFPE 2021). |
 | `kmc_ff` | **K-Minimum Cut, First-Fit.** Select path that minimises cut metric, then first-fit. |
 | `kmf_ff` | **K-Minimum Fragmentation, First-Fit.** Select path that minimises fragmentation, then first-fit. |
 | `kme_ff` | **K-Minimum Entropy, First-Fit.** Select path whose allocation causes the smallest increase in spectrum fragmentation entropy (Wright, Parker & Lord, JOCN 2015), then first-fit. |
 | `kca_ff` | **Congestion-Aware, First-Fit.** Select the least-congested feasible path (occupancy-weighted link length), then first-fit. |
 
 Default: `ksp_ff`.
+
+### `--mscl_interfering_k`
+
+Number of stored routes per node pair in the interfering route set of the MSCL heuristics (`ksp_mscl`, `mscl_ksp`). The capacity loss of a candidate placement is accounted on every route in this set that shares a link with the candidate path, so larger values price in damage to a pair's alternative routes at proportionally higher compute and memory cost.
+
+| Value | Description |
+|-------|-------------|
+| `1` | Only each pair's first stored path — the single-route set of the original 2013 formulation (Almeida Jr. et al.). Default. |
+| `0` | All `k` stored paths per pair — the full multi-route formulation of dos Santos (UFPE 2021): `ksp_mscl` becomes MSCL Sequencial and `mscl_ksp` becomes MSCL Combinado. |
+| `n` | The first `n` stored paths per pair (intermediate cost/fidelity trade-off). |
+
+On large topologies with high `k` (e.g. 100+ nodes, k=90), the full multi-route set can require gigabytes of intermediate arrays — use an intermediate value if memory-constrained.
+
+Reference: M. L. dos Santos, "Abordagens para atribuição de espectro em redes ópticas elásticas baseadas em perda de capacidade sob múltiplas rotas", M.Sc. dissertation, Universidade Federal de Pernambuco, 2021. [repositorio.ufpe.br/handle/123456789/45594](https://repositorio.ufpe.br/handle/123456789/45594)
 
 ### `--path_sort_criteria`
 

--- a/xlron/environments/dataclasses.py
+++ b/xlron/environments/dataclasses.py
@@ -238,6 +238,8 @@ class RSAEnvParams(EnvParams):
         path_se_array (Array): Path spectral efficiency array
         deterministic_requests (bool): If True, use deterministic requests
         multiple_topologies (bool): If True, use multiple topologies
+        mscl_interfering_k (int): Stored routes per node pair in the interfering
+            route set of the multi-route MSCL heuristics (0 = all k paths)
     """
 
     max_slots: chex.Scalar = struct.field(pytree_node=False)
@@ -245,6 +247,7 @@ class RSAEnvParams(EnvParams):
     multiple_topologies: bool = struct.field(pytree_node=False)
     log_actions: bool = struct.field(pytree_node=False)
     disable_node_features: bool = struct.field(pytree_node=False)
+    mscl_interfering_k: int = struct.field(pytree_node=False)
 
 
 @struct.dataclass

--- a/xlron/environments/make_env.py
+++ b/xlron/environments/make_env.py
@@ -872,6 +872,11 @@ def make(
         num_spectral_features=config.get("num_spectral_features", 8),
         line_graph_spectral_features=line_graph_spectral_features,
         include_no_op=config.get("include_no_op", False),
+        # 0 is a meaningful value (all k paths), so only fall back to the
+        # single-route default of 1 when the key is absent entirely
+        mscl_interfering_k=int(
+            1 if config.get("mscl_interfering_k") is None else config.get("mscl_interfering_k")
+        ),
         transformer_obs_type=transformer_obs_type,
         use_gnn=config.get("USE_GNN"),
         profile=profile,

--- a/xlron/gui/widgets.py
+++ b/xlron/gui/widgets.py
@@ -224,6 +224,7 @@ DEFAULTS = {
     "maximum_path_length_km": None,
     # Heuristics
     "path_heuristic": "ksp_ff",
+    "mscl_interfering_k": 1,
     "EVAL_HEURISTIC": False,
     "EVAL_MODEL": False,
     "RETRAIN_MODEL": False,
@@ -424,6 +425,14 @@ def execution_mode_section() -> dict:
             help=_h("path_heuristic"),
         )
         _emit(flags, "path_heuristic", heuristic)
+        if heuristic in ("ksp_mscl", "mscl_ksp"):
+            mscl_k = st.number_input(
+                "MSCL Interfering Routes per Pair (0 = all k, 1 = shortest only)",
+                min_value=0,
+                value=int(_get_preset_val("mscl_interfering_k")),
+                help=_h("mscl_interfering_k"),
+            )
+            _emit(flags, "mscl_interfering_k", int(mscl_k))
 
     elif mode == "Model Evaluation":
         flags["EVAL_MODEL"] = True

--- a/xlron/heuristics/heuristics.py
+++ b/xlron/heuristics/heuristics.py
@@ -206,6 +206,16 @@ def ksp_flef(state: RSAEnvState, params: RSAEnvParams) -> Array:
     return action
 
 
+def _mscl_num_interfering_routes(params: RSAEnvParams) -> int:
+    """Resolve the mscl_interfering_k param to a per-pair route count for the
+    MSCL heuristics (0 = all k_paths stored routes; unset = 1, the single-route
+    set of the original 2013 formulation). params is static under jit, so this
+    runs in Python at trace time."""
+    n = getattr(params, "mscl_interfering_k", 1)
+    n = params.k_paths if n == 0 else n
+    return int(min(n, params.k_paths))
+
+
 @partial(jax.jit, static_argnums=(1,))
 def ksp_mscl(state: RSAEnvState, params: RSAEnvParams) -> Array:
     """K-Shortest Path, Minimum Slot-continuity Capacity Loss (MSCL).
@@ -220,9 +230,22 @@ def ksp_mscl(state: RSAEnvState, params: RSAEnvParams) -> Array:
     placement that destroys least. See capacity_loss for the metric definition,
     the closed-form computation, and full references.
 
-    Reference: R. C. Almeida Jr. et al., "Slot assignment strategy to reduce loss
-    of capacity of contiguous-slot path requests in flexible grid optical
-    networks", Electronics Letters 49(5), 2013, doi:10.1049/el.2012.4247.
+    The loss is accounted over the first --mscl_interfering_k stored routes of
+    every node pair sharing a link with the candidate path (0 = all k_paths).
+    With the default of 1 this is the single-route interfering set of the
+    original 2013 formulation; with 0 it is the multi-route set of dos Santos
+    (2021), whose MSCL Sequencial is exactly this heuristic (sequential route
+    choice, min-loss slot). Cost scales linearly with the interfering-set size.
+
+    References:
+        R. C. Almeida Jr. et al., "Slot assignment strategy to reduce loss of
+        capacity of contiguous-slot path requests in flexible grid optical
+        networks", Electronics Letters 49(5), 2013, doi:10.1049/el.2012.4247.
+        M. L. dos Santos, "Abordagens para atribuicao de espectro em redes
+        opticas elasticas baseadas em perda de capacidade sob multiplas rotas",
+        M.Sc. dissertation, Universidade Federal de Pernambuco, Recife, 2021,
+        sec. 3.1 (MSCL Sequencial).
+        https://repositorio.ufpe.br/handle/123456789/45594
 
     Args:
         state (EnvState): Environment state
@@ -231,7 +254,8 @@ def ksp_mscl(state: RSAEnvState, params: RSAEnvParams) -> Array:
     Returns:
         Array: Action
     """
-    loss, mask = capacity_loss(state, params)
+    n_int = _mscl_num_interfering_routes(params)
+    loss, mask = capacity_loss(state, params, num_interfering_routes=n_int)
     # Chosen path is the first one with an available slot
     available_paths = jnp.max(mask, axis=1)
     path_index = jnp.argmax(available_paths)
@@ -252,6 +276,22 @@ def mscl_ksp(state: RSAEnvState, params: RSAEnvParams) -> Array:
     then the lowest slot index. See capacity_loss for the metric definition, the
     closed-form computation, and full references.
 
+    The loss is accounted over the first --mscl_interfering_k stored routes of
+    every node pair sharing a link with the candidate path (0 = all k_paths).
+    With the default of 1 this is the single-route interfering set of the
+    original 2013 formulation; with 0 it is the multi-route set of dos Santos
+    (2021), whose MSCL Combinado is exactly this heuristic (joint route-slot
+    choice; the flowchart's strict-improvement scan over routes and slots in
+    order yields the same tie-breaks as the flattened argmin here). Cost scales
+    linearly with the interfering-set size.
+
+    References:
+        R. C. Almeida Jr. et al., Electronics Letters 49(5), 2013,
+        doi:10.1049/el.2012.4247 (see ksp_mscl).
+        M. L. dos Santos, M.Sc. dissertation, Universidade Federal de
+        Pernambuco, Recife, 2021, sec. 3.2 (MSCL Combinado).
+        https://repositorio.ufpe.br/handle/123456789/45594
+
     Args:
         state (EnvState): Environment state
         params (EnvParams): Environment parameters
@@ -259,7 +299,8 @@ def mscl_ksp(state: RSAEnvState, params: RSAEnvParams) -> Array:
     Returns:
         Array: Action
     """
-    loss, _ = capacity_loss(state, params)
+    n_int = _mscl_num_interfering_routes(params)
+    loss, _ = capacity_loss(state, params, num_interfering_routes=n_int)
     # argmin over path-major flattened array ties-breaks to shortest path, lowest slot
     action = jnp.argmin(loss.reshape(-1))
     return action
@@ -901,7 +942,9 @@ def exact_fit(state: EnvState, params: RSAEnvParams) -> Tuple[Array, Array, Arra
     return first_exact, last_exact, mask
 
 
-def capacity_loss(state: EnvState, params: RSAEnvParams) -> Tuple[Array, Array]:
+def capacity_loss(
+    state: EnvState, params: RSAEnvParams, num_interfering_routes: int = 1
+) -> Tuple[Array, Array]:
     """Slot-continuity capacity loss (the MSCL metric) of every candidate
     (path, slot) assignment for the current request.
 
@@ -954,13 +997,24 @@ def capacity_loss(state: EnvState, params: RSAEnvParams) -> Tuple[Array, Array]:
         heuristics_test.py::CapacityLossBruteforceTest.
 
     Interfering route set
-        The affected routes are the shortest path of every node pair that shares
-        a link with the candidate route (the single-route-per-pair route set of
-        the original 2013 formulation), plus the candidate route itself - counted
-        once, since when the candidate is its pair's k=0 path it already is that
-        pair's shortest. Multi-route interfering sets (every stored path of every
-        pair) are a published extension (Santos et al., SBrT 2021) and would cost
-        k times more here.
+        Two routes interfere when they share at least one link. The routes whose
+        capacity loss is accounted are controlled by num_interfering_routes = n:
+        the first n stored paths of every node pair that share a link with the
+        candidate route, plus the candidate route itself - counted once, since a
+        candidate with k-index below n already is one of its own pair's first n
+        stored routes. n = 1 (the default) is the single-route-per-pair set of
+        the original 2013 formulation. n = k_paths is the all-stored-routes set
+        of the multi-route extension of dos Santos (2021): it also prices in the
+        damage a placement does to a pair's alternative routes (which future
+        traffic will actually be offered to under KSP routing), at n times the
+        cost and memory of the single-route set. The ksp_mscl and mscl_ksp
+        heuristics choose n via the --mscl_interfering_k flag (0 = all k_paths).
+
+    Args:
+        state (EnvState): Environment state
+        params (EnvParams): Environment parameters
+        num_interfering_routes (int): Stored routes per node pair in the
+            interfering set (static at trace time; 1 <= n <= k_paths)
 
     References
         R. C. Almeida Jr., A. F. dos Santos, K. D. R. Assis, H. Waldman &
@@ -970,9 +1024,13 @@ def capacity_loss(state: EnvState, params: RSAEnvParams) -> Tuple[Array, Array]:
         X. Zhang & C. Qiao, "Wavelength assignment for dynamic traffic in
         multi-fiber WDM networks", ICCCN 1998 - the relative-capacity-loss RWA
         metric that MSCL generalises to contiguous-spectrum RSA/RMSA.
-        M. L. Santos, R. C. Almeida Jr. & D. R. B. Araujo, "Multi-route spectrum
-        assignment by slot-continuity capacity loss in elastic optical networks",
-        SBrT 2021 - multi-route interfering sets.
+        M. L. dos Santos, "Abordagens para atribuicao de espectro em redes
+        opticas elasticas baseadas em perda de capacidade sob multiplas rotas"
+        (Approaches for spectrum assignment in elastic optical networks based on
+        capacity loss under multiple routes), M.Sc. dissertation, Universidade
+        Federal de Pernambuco, Recife, 2021.
+        https://repositorio.ufpe.br/handle/123456789/45594 - multi-route
+        interfering sets; the MSCL Sequencial and MSCL Combinado heuristics.
 
     Returns:
         Tuple: (loss, mask). loss is (k_paths, link_resources) float32 with jnp.inf
@@ -994,12 +1052,23 @@ def capacity_loss(state: EnvState, params: RSAEnvParams) -> Tuple[Array, Array]:
     w_cap = int(np.ceil(float(np.max(values_bw)) / (min_se * float(params.slot_size))))
     w_cap = max(w_cap + int(params.guardband), 1)
 
-    # Interfering route set: the shortest path of every node pair (rows of the
-    # path-link array are pair-major with k consecutive rows per pair)
-    shortest_paths = params.path_link_array.val[:: params.k_paths]
+    # Interfering route set: the first n stored paths of every node pair (rows of
+    # the path-link array are pair-major with k consecutive rows per pair);
+    # n = 1 selects every pair's shortest path only (the 2013 formulation)
+    n_int = int(num_interfering_routes)
+    if not 1 <= n_int <= params.k_paths:
+        raise ValueError(
+            f"num_interfering_routes must be in [1, k_paths={params.k_paths}], got {n_int}"
+        )
+    pair_major_rows = (
+        np.arange(params.path_link_array.val.shape[0])
+        .reshape(-1, params.k_paths)[:, :n_int]
+        .reshape(-1)
+    )
+    interfering_paths = params.path_link_array.val[pair_major_rows]
     if params.pack_path_bits:
-        shortest_paths = jnp.unpackbits(shortest_paths, axis=1)[:, : params.num_links]
-    shortest_paths = jnp.asarray(shortest_paths, dtype=jnp.float32)
+        interfering_paths = jnp.unpackbits(interfering_paths, axis=1)[:, : params.num_links]
+    interfering_paths = jnp.asarray(interfering_paths, dtype=jnp.float32)
     cand_paths = jnp.asarray(get_paths(params, nodes_sd), dtype=jnp.float32)
 
     def prep(paths):
@@ -1029,34 +1098,32 @@ def capacity_loss(state: EnvState, params: RSAEnvParams) -> Tuple[Array, Array]:
         gap = run_end - slot_indices[None, :]
         return sum_min(d, gap) - sum_min(d, 0)
 
-    short_start, short_end, short_cum = prep(shortest_paths)
+    intf_start, intf_end, intf_cum = prep(interfering_paths)
     cand_start, cand_end, cand_cum = prep(cand_paths)
 
-    # Loss on interfering (shortest-per-pair) routes: truncation left of s plus the
-    # capacity of positions inside [s, e) that become occupied. Since the block end
+    # Loss on the interfering routes: truncation left of s plus the capacity of
+    # positions inside [s, e) that become occupied. Since the block end
     # e = s + w_r depends on the candidate path only through its width w_r, the sum
     # over interfering routes commutes with the gather at e: everything reduces to
-    # matmuls over the pair dimension plus one shifted gather of the aggregate,
-    # avoiding a (num_pairs, k, S) intermediate. Aggregates can reach ~1e7 on
+    # matmuls over the route dimension plus one shifted gather of the aggregate,
+    # avoiding a (num_pairs * n, k, S) intermediate. Aggregates can reach ~1e7 on
     # 100+-node topologies, so float32 rounding of ~1 capacity unit is possible in
     # near-tied candidates; the ranking is unaffected for practical purposes (the
     # brute-force equality test runs on small topologies where sums stay exact).
-    short_trunc = truncation_loss(short_start, short_end)  # (num_pairs, S)
-    shares = (jnp.dot(cand_paths, shortest_paths.T) > 0).astype(jnp.float32)  # (k, P)
-    base = jnp.dot(
-        shares, (short_trunc - short_cum[:, :num_resources]).astype(jnp.float32)
-    )  # (k, S)
-    cum_agg = jnp.dot(shares, short_cum.astype(jnp.float32))  # (k, S + 1)
+    intf_trunc = truncation_loss(intf_start, intf_end)  # (num_pairs * n, S)
+    shares = (jnp.dot(cand_paths, interfering_paths.T) > 0).astype(jnp.float32)  # (k, P * n)
+    base = jnp.dot(shares, (intf_trunc - intf_cum[:, :num_resources]).astype(jnp.float32))  # (k, S)
+    cum_agg = jnp.dot(shares, intf_cum.astype(jnp.float32))  # (k, S + 1)
     loss = base + jnp.take_along_axis(cum_agg, ends, axis=1)
 
-    # Same loss terms on the candidate route itself. The candidate is already in
-    # the interfering set iff it is its pair's shortest path (k index 0);
-    # otherwise add its own loss explicitly
+    # Same loss terms on the candidate route itself. A candidate with k-index
+    # below n is already in the interfering set (it is one of its own pair's
+    # first n stored routes); otherwise add its own loss explicitly
     cand_trunc = truncation_loss(cand_start, cand_end)  # (k, S)
     cand_inside = jnp.take_along_axis(cand_cum, ends, axis=1) - cand_cum[:, :num_resources]
     cand_delta = cand_trunc + cand_inside
-    not_shortest = (jnp.arange(params.k_paths) != 0).astype(jnp.float32)[:, None]
-    loss = loss + cand_delta.astype(jnp.float32) * not_shortest
+    not_in_set = (jnp.arange(params.k_paths) >= n_int).astype(jnp.float32)[:, None]
+    loss = loss + cand_delta.astype(jnp.float32) * not_in_set
     loss = jnp.where(mask == 0, jnp.inf, loss)
     return loss, mask
 

--- a/xlron/heuristics/heuristics_test.py
+++ b/xlron/heuristics/heuristics_test.py
@@ -14584,10 +14584,12 @@ class MsclTest(chex.TestCase):
         chex.assert_trees_all_close(action, expected)
 
 
-def _bruteforce_capacity_loss(state, params):
+def _bruteforce_capacity_loss(state, params, num_interfering_routes=1):
     """Reference implementation of the MSCL capacity loss: recompute the number of
     feasible contiguous placements before/after each candidate assignment by direct
-    counting over updated spectrum states."""
+    counting over updated spectrum states. num_interfering_routes selects the first
+    n stored routes of every node pair as the interfering set (1 = the 2013
+    single-route formulation; k_paths = the dos Santos 2021 multi-route set)."""
     import numpy as np
 
     from xlron.environments.env_funcs import get_paths, read_rsa_request
@@ -14595,12 +14597,15 @@ def _bruteforce_capacity_loss(state, params):
     from xlron.heuristics.heuristics import get_request_num_slots
 
     k = params.k_paths
+    n_int = num_interfering_routes
     num_slots_arr = np.asarray(get_request_num_slots(state, params))
     mask = np.asarray(get_action_mask(state, params))
     S = params.link_resources
     lsa_occ = np.asarray(state.link_slot_array) != 0
     path_link_array = np.asarray(params.path_link_array.val)
-    shortest = path_link_array[::k]
+    interfering = path_link_array.reshape(-1, k, path_link_array.shape[1])[:, :n_int].reshape(
+        -1, path_link_array.shape[1]
+    )
     nodes_sd, _ = read_rsa_request(state.request_array)
     cand_paths = np.asarray(get_paths(params, nodes_sd))
 
@@ -14630,9 +14635,11 @@ def _bruteforce_capacity_loss(state, params):
     loss = np.full((k, S), np.inf)
     for r in range(k):
         routes = [
-            shortest[p] for p in range(shortest.shape[0]) if (shortest[p] * cand_paths[r]).sum() > 0
+            interfering[p]
+            for p in range(interfering.shape[0])
+            if (interfering[p] * cand_paths[r]).sum() > 0
         ]
-        if r != 0:
+        if r >= n_int:
             routes.append(cand_paths[r])
         for s in range(S):
             if mask[r, s] == 0:
@@ -14653,7 +14660,15 @@ class CapacityLossBruteforceTest(chex.TestCase):
     """Property test: the closed-form capacity_loss must match a direct
     before/after recount of feasible placements on random spectrum states."""
 
-    def _run_comparison(self, setup_fn, request_array, seed, occupancy=0.4, **setup_kwargs):
+    def _run_comparison(
+        self,
+        setup_fn,
+        request_array,
+        seed,
+        occupancy=0.4,
+        num_interfering_routes=1,
+        **setup_kwargs,
+    ):
         import numpy as np
 
         key, env, obs, state, params = setup_fn(**setup_kwargs)
@@ -14666,8 +14681,10 @@ class CapacityLossBruteforceTest(chex.TestCase):
             request_array=jnp.array(request_array),
             link_slot_array=jnp.array(lsa * signs),
         )
-        expected = _bruteforce_capacity_loss(state, params)
-        actual, _ = capacity_loss(state, params)
+        expected = _bruteforce_capacity_loss(
+            state, params, num_interfering_routes=num_interfering_routes
+        )
+        actual, _ = capacity_loss(state, params, num_interfering_routes=num_interfering_routes)
         chex.assert_trees_all_close(jnp.array(expected), actual)
 
     def test_4node(self):
@@ -14682,13 +14699,153 @@ class CapacityLossBruteforceTest(chex.TestCase):
                 rsa_4node_3_slot_request_test_setup, [1, 3, 3], seed, link_resources=10
             )
 
+    def test_4node_multiroute(self):
+        # k_paths = 2 in this setup, so n = 2 is the full multi-route set
+        for seed in range(5):
+            self._run_comparison(
+                rsa_4node_3_slot_request_test_setup,
+                [0, 3, 1],
+                seed,
+                num_interfering_routes=2,
+                link_resources=10,
+            )
+
     def test_nsfnet(self):
         for seed in range(3):
             self._run_comparison(rsa_nsfnet_16_test_setup, [0, 3, 7], seed)
 
+    def test_nsfnet_multiroute(self):
+        for seed in range(3):
+            for n_int in (2, 5):
+                self._run_comparison(
+                    rsa_nsfnet_16_test_setup, [0, 3, 7], seed, num_interfering_routes=n_int
+                )
+
     def test_nsfnet_modulation(self):
         for seed in range(3):
             self._run_comparison(rsa_nsfnet_16_mod_test_setup, [0, 100, 7], seed)
+
+    def test_nsfnet_modulation_multiroute(self):
+        for seed in range(3):
+            self._run_comparison(
+                rsa_nsfnet_16_mod_test_setup, [0, 100, 7], seed, num_interfering_routes=5
+            )
+
+
+class MsclMultirouteTest(chex.TestCase):
+    """Tests for the MSCL heuristics with the multi-route interfering set
+    (mscl_interfering_k = 0 -> all k paths per pair: MSCL Sequencial / Combinado
+    of dos Santos, UFPE 2021) on the 4-node RSA setup (5 slots, 3-slot requests,
+    k_paths = 2; path 0 for 0->1 uses link 0, path 1 uses links 1,2,3)."""
+
+    def setUp(self):
+        super().setUp()
+        self.key, self.env, self.obs, self.state, self.params = (
+            rsa_4node_3_slot_request_test_setup()
+        )
+        # All k stored routes per pair in the interfering set
+        self.params_multi = self.params.replace(mscl_interfering_k=0)
+
+    @chex.all_variants()
+    @parameterized.named_parameters(
+        # Empty spectrum: edge placements tie at minimum loss on the first path;
+        # ties break to the lowest slot (as with the single-route set)
+        ("case_empty", jnp.array([0, 3, 1]), jnp.zeros((4, 5)), jnp.array(0)),
+        (
+            # Only slot 1 fits on path 0 (run of exactly 3 at slots 1-3)
+            "case_single_option",
+            jnp.array([0, 3, 1]),
+            jnp.array(
+                [
+                    [1, 0, 0, 0, 1],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            jnp.array(1),
+        ),
+        (
+            # Path 0 full: fall through to path 1
+            "case_second_path",
+            jnp.array([0, 3, 1]),
+            jnp.array(
+                [
+                    [1, 1, 1, 1, 1],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            jnp.array(5),
+        ),
+    )
+    def test_ksp_mscl_multiroute(self, request_array, link_slot_array, expected):
+        self.state = self.state.replace(
+            request_array=request_array, link_slot_array=link_slot_array
+        )
+        action = self.variant(ksp_mscl, static_argnums=(1,))(self.state, self.params_multi)
+        chex.assert_trees_all_close(action, expected)
+
+    @chex.all_variants()
+    @parameterized.named_parameters(
+        (
+            "case_second_path",
+            jnp.array([0, 3, 1]),
+            jnp.array(
+                [
+                    [1, 1, 1, 1, 1],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0],
+                ]
+            ),
+            jnp.array(5),
+        ),
+    )
+    def test_mscl_ksp_multiroute(self, request_array, link_slot_array, expected):
+        self.state = self.state.replace(
+            request_array=request_array, link_slot_array=link_slot_array
+        )
+        action = self.variant(mscl_ksp, static_argnums=(1,))(self.state, self.params_multi)
+        chex.assert_trees_all_close(action, expected)
+
+    def _random_state(self, seed, occupancy=0.4):
+        import numpy as np
+
+        rng = np.random.default_rng(seed)
+        lsa = (rng.random((self.params.num_links, self.params.link_resources)) < occupancy).astype(
+            np.float32
+        )
+        return self.state.replace(
+            request_array=jnp.array([0, 3, 1]), link_slot_array=jnp.array(lsa)
+        )
+
+    def test_mscl_ksp_multiroute_actions_match_bruteforce(self):
+        # The joint (path, slot) argmin over the multi-route loss must match the
+        # brute-force reference metric (ties break to lowest flattened index)
+        import numpy as np
+
+        for seed in range(5):
+            state = self._random_state(seed)
+            expected_loss = _bruteforce_capacity_loss(
+                state, self.params, num_interfering_routes=self.params.k_paths
+            )
+            action = mscl_ksp(state, self.params_multi)
+            chex.assert_trees_all_close(action, jnp.array(np.argmin(expected_loss.reshape(-1))))
+
+    def test_explicit_single_route_set_matches_default(self):
+        # mscl_interfering_k = 1 (explicit) must select identically to the default
+        # params (the flag defaults to 1, i.e. the single-route 2013 formulation)
+        params_single = self.params.replace(mscl_interfering_k=1)
+        for seed in range(5):
+            state = self._random_state(seed)
+            chex.assert_trees_all_close(
+                ksp_mscl(state, params_single), ksp_mscl(state, self.params)
+            )
+            chex.assert_trees_all_close(
+                mscl_ksp(state, params_single), mscl_ksp(state, self.params)
+            )
 
 
 class ExactFitBruteforceTest(chex.TestCase):

--- a/xlron/parameter_flags.py
+++ b/xlron/parameter_flags.py
@@ -627,6 +627,14 @@ flags.DEFINE_string("node_probs", None, "List of node probabilities for selectio
 flags.DEFINE_boolean("EVAL_HEURISTIC", False, "Evaluate heuristic")
 flags.DEFINE_string("path_heuristic", "ksp_ff", "Path heuristic to be evaluated")
 flags.DEFINE_string("node_heuristic", "random", "Node heuristic to be evaluated")
+flags.DEFINE_integer(
+    "mscl_interfering_k",
+    1,
+    "Stored routes per node pair in the interfering route set of the MSCL heuristics "
+    "(ksp_mscl, mscl_ksp). 1 (default) = the single-route-per-pair set of the original 2013 "
+    "formulation; 0 = all k paths, giving the multi-route MSCL Sequencial/Combinado of "
+    "dos Santos (2021). Compute and memory scale linearly with this value.",
+)
 # GNN-specific parameters
 flags.DEFINE_boolean("USE_GNN", False, "Use GNN")
 flags.DEFINE_integer("num_spectral_features", 8, "No. of spectral features")


### PR DESCRIPTION
## Summary

The MSCL heuristics (`ksp_mscl`, `mscl_ksp`) previously accounted slot-continuity capacity loss over a **single route per node pair** (each pair's shortest path), following the original 2013 formulation (Almeida Jr. et al., Electron. Lett.). Under KSP routing, future traffic is frequently served on a pair's *alternative* routes — so the single-route metric is blind to the damage a placement does to those routes, and overcharges damage to the shortest path.

This PR generalises the metric to an interfering set of the first **n** stored routes per pair, exposed through a new `--mscl_interfering_k` flag:

| `--mscl_interfering_k` | Interfering set | Equivalent to |
|---|---|---|
| `1` (default) | shortest path per pair | original 2013 MSCL (unchanged behaviour) |
| `0` | all `k` stored routes per pair | multi-route MSCL Sequencial (`ksp_mscl`) / Combinado (`mscl_ksp`) of dos Santos (UFPE 2021) |
| `n` | first `n` routes per pair | cost/fidelity dial |

Compute and memory scale linearly with `n`; the closed-form capacity-loss decomposition is otherwise unchanged (only the interfering-route matmul dimension grows).

## The Sequencial / Combinado naming

The dissertation's *MSCL Sequencial* vs *Combinado* distinguish **route-choice policy** (first-feasible route vs joint route+slot argmin), which XLRON already encodes as `ksp_mscl` vs `mscl_ksp`. The multi-route ("multiplas rotas") contribution is the **interfering-set** upgrade, common to both. So rather than adding two new heuristic names, this keeps the existing two and adds the interfering-set dial — `ksp_mscl --mscl_interfering_k=0` **is** MSCL Sequencial and `mscl_ksp --mscl_interfering_k=0` **is** MSCL Combinado.

## Testing

- Property tests compare the closed form against a brute-force before/after recount at `n` in {2, 5, k} on the 4-node and NSFNET setups (with and without modulation).
- New tests pin `--mscl_interfering_k=1` to the prior single-route behaviour (`ksp_mscl`/`mscl_ksp` unchanged) and verify the joint `mscl_ksp` argmin matches the brute-force multi-route metric.
- Full heuristics suite passes (598 passed, 147 skipped); env, dtype, dispatch, and train-smoke suites pass.
- End-to-end equivalence verified: `mscl_ksp` with defaults reproduces pre-change blocking bit-identically; `--mscl_interfering_k=0` reproduces the multi-route run bit-identically.

## Note on performance

On NSFNET (k=5, load 250) the multi-route set was slightly *worse* than single-route (e.g. `mscl_ksp` 1.82% vs 1.56% blocking). This does not contradict the dissertation, which only ever benchmarks against First-Fit — never against the 2013 single-route MSCL. The default is therefore `1` (unchanged behaviour); the multi-route set is opt-in. A `--mscl_interfering_k` sweep across topologies is worthwhile before assuming larger sets help.

## Reference

M. L. dos Santos, "Abordagens para atribuicao de espectro em redes opticas elasticas baseadas em perda de capacidade sob multiplas rotas", M.Sc. dissertation, Universidade Federal de Pernambuco, Recife, 2021. https://repositorio.ufpe.br/handle/123456789/45594

🤖 Generated with [Claude Code](https://claude.com/claude-code)
